### PR TITLE
Refactor main into modular classes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "sstream": "cpp",
-        "regex": "cpp"
+        "regex": "cpp",
+        "new": "cpp"
     }
 }

--- a/src/AnimationManager.cpp
+++ b/src/AnimationManager.cpp
@@ -1,0 +1,227 @@
+#include "AnimationManager.hpp"
+
+AnimationManager *AnimationManager::instance_ = nullptr;
+
+AnimationManager::AnimationManager(int panelResX, int panelResY, int panelChainLength)
+    : panelResX_(panelResX),
+      panelResY_(panelResY),
+      panelChainLength_(panelChainLength),
+      display_(nullptr),
+      gifFile_(),
+      colorRed_(0),
+      colorGreen_(0),
+      colorBlue_(0),
+      colorWhite_(0),
+      colorYellow_(0),
+      colorCyan_(0),
+      colorMagenta_(0),
+      colorBlack_(0) {
+  instance_ = this;
+}
+
+AnimationManager::~AnimationManager() {
+  if (display_ != nullptr) {
+    delete display_;
+    display_ = nullptr;
+  }
+  if (instance_ == this) {
+    instance_ = nullptr;
+  }
+}
+
+bool AnimationManager::begin() {
+  HUB75_I2S_CFG mxconfig(panelResX_, panelResY_, panelChainLength_);
+  mxconfig.gpio.e = 18;
+  mxconfig.clkphase = false;
+
+  display_ = new MatrixPanel_I2S_DMA(mxconfig);
+  display_->begin();
+
+  initializeColors();
+
+  display_->fillScreen(colorBlack_);
+  display_->setCursor(5, 0);
+  display_->setTextColor(colorBlue_);
+  display_->println("Startup...");
+
+  if (!SPIFFS.begin(true)) {
+    Serial.println(F("SPIFFS mount failed!"));
+    return false;
+  }
+
+  gif_.begin(LITTLE_ENDIAN_PIXELS);
+
+  listSPIFFS();
+  return true;
+}
+
+void AnimationManager::playEmotion(const String &emotionPath) {
+  if (!display_) {
+    return;
+  }
+
+  if (gif_.open(emotionPath.c_str(), fileOpenWrapper, fileCloseWrapper, fileReadWrapper, fileSeekWrapper, GIFDrawWrapper)) {
+    gif_.playFrame(true, nullptr);
+    gif_.close();
+  }
+}
+
+void AnimationManager::listSPIFFS() {
+  Serial.println(F("SPIFFS contents:"));
+  File root = SPIFFS.open("/");
+  if (!root) {
+    Serial.println(F("Failed to open root directory"));
+    return;
+  }
+  if (!root.isDirectory()) {
+    Serial.println(F("Root is not a directory"));
+    return;
+  }
+
+  File file = root.openNextFile();
+  while (file) {
+    Serial.printf("  %s  (%d bytes)\n", file.name(), file.size());
+    file = root.openNextFile();
+  }
+  Serial.println(F("---- End of SPIFFS listing ----"));
+}
+
+void AnimationManager::GIFDrawWrapper(GIFDRAW *pDraw) {
+  if (instance_) {
+    instance_->GIFDraw(pDraw);
+  }
+}
+
+void *AnimationManager::fileOpenWrapper(const char *filename, int32_t *pFileSize) {
+  return instance_ ? instance_->fileOpen(filename, pFileSize) : nullptr;
+}
+
+void AnimationManager::fileCloseWrapper(void *pHandle) {
+  if (instance_) {
+    instance_->fileClose(pHandle);
+  }
+}
+
+int32_t AnimationManager::fileReadWrapper(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen) {
+  return instance_ ? instance_->fileRead(pHandle, pBuf, iLen) : 0;
+}
+
+int32_t AnimationManager::fileSeekWrapper(GIFFILE *pHandle, int32_t iPosition) {
+  return instance_ ? instance_->fileSeek(pHandle, iPosition) : -1;
+}
+
+void AnimationManager::GIFDraw(GIFDRAW *pDraw) {
+  uint8_t *s;
+  uint16_t *d, *usPalette, usTemp[320];
+  int x, y;
+
+  usPalette = pDraw->pPalette;
+  y = pDraw->iY + pDraw->y;
+
+  s = pDraw->pPixels;
+  if (pDraw->ucDisposalMethod == 2) {
+    for (x = 0; x < pDraw->iWidth; x++) {
+      if (s[x] == pDraw->ucTransparent) {
+        s[x] = pDraw->ucBackground;
+      }
+    }
+    pDraw->ucHasTransparency = 0;
+  }
+
+  if (pDraw->ucHasTransparency) {
+    uint8_t *pEnd, c, ucTransparent = pDraw->ucTransparent;
+    int iCount = 0;
+    pEnd = s + pDraw->iWidth;
+    x = 0;
+    while (x < pDraw->iWidth) {
+      c = ucTransparent - 1;
+      d = usTemp;
+      while (c != ucTransparent && s < pEnd) {
+        c = *s++;
+        if (c == ucTransparent) {
+          s--;
+        } else {
+          *d++ = usPalette[c];
+          iCount++;
+        }
+      }
+      if (iCount) {
+        for (int xOffset = 0; xOffset < iCount; xOffset++) {
+          display_->drawPixel(x + xOffset + pDraw->iX, y, usTemp[xOffset]);
+        }
+        x += iCount;
+        iCount = 0;
+      }
+      c = ucTransparent;
+      while (c == ucTransparent && s < pEnd) {
+        c = *s++;
+        if (c == ucTransparent) {
+          iCount++;
+        } else {
+          s--;
+        }
+      }
+      if (iCount) {
+        x += iCount;
+        iCount = 0;
+      }
+    }
+  } else {
+    s = pDraw->pPixels;
+    for (x = 0; x < pDraw->iWidth; x++) {
+      display_->drawPixel(x + pDraw->iX, y, usPalette[*s++]);
+    }
+  }
+}
+
+void *AnimationManager::fileOpen(const char *filename, int32_t *pFileSize) {
+  gifFile_ = SPIFFS.open(filename, FILE_READ);
+  if (!gifFile_) {
+    Serial.printf("Failed to open GIF file from SPIFFS: %s\n", filename);
+    *pFileSize = 0;
+    return nullptr;
+  }
+  *pFileSize = gifFile_.size();
+  return &gifFile_;
+}
+
+void AnimationManager::fileClose(void *pHandle) {
+  (void)pHandle;
+  if (gifFile_) {
+    gifFile_.close();
+  }
+}
+
+int32_t AnimationManager::fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen) {
+  (void)pHandle;
+  if (!gifFile_) {
+    return 0;
+  }
+  return gifFile_.read(pBuf, static_cast<size_t>(iLen));
+}
+
+int32_t AnimationManager::fileSeek(GIFFILE *pHandle, int32_t iPosition) {
+  (void)pHandle;
+  if (!gifFile_) {
+    return -1;
+  }
+  if (iPosition < 0) {
+    iPosition = 0;
+  }
+  if (iPosition > static_cast<int32_t>(gifFile_.size())) {
+    iPosition = gifFile_.size();
+  }
+  gifFile_.seek(iPosition, SeekSet);
+  return iPosition;
+}
+
+void AnimationManager::initializeColors() {
+  colorRed_ = display_->color565(255, 0, 0);
+  colorGreen_ = display_->color565(0, 255, 0);
+  colorBlue_ = display_->color565(0, 0, 255);
+  colorWhite_ = display_->color565(255, 255, 255);
+  colorYellow_ = display_->color565(255, 255, 0);
+  colorCyan_ = display_->color565(0, 255, 255);
+  colorMagenta_ = display_->color565(255, 0, 255);
+  colorBlack_ = display_->color565(0, 0, 0);
+}

--- a/src/AnimationManager.hpp
+++ b/src/AnimationManager.hpp
@@ -1,0 +1,53 @@
+#ifndef ANIMATION_MANAGER_HPP
+#define ANIMATION_MANAGER_HPP
+
+#include <AnimatedGIF.h>
+#include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
+#include <SPIFFS.h>
+
+#include <Arduino.h>
+
+class AnimationManager {
+public:
+  AnimationManager(int panelResX, int panelResY, int panelChainLength);
+  ~AnimationManager();
+
+  bool begin();
+  void playEmotion(const String &emotionPath);
+  void listSPIFFS();
+
+private:
+  static AnimationManager *instance_;
+
+  static void GIFDrawWrapper(GIFDRAW *pDraw);
+  static void *fileOpenWrapper(const char *filename, int32_t *pFileSize);
+  static void fileCloseWrapper(void *pHandle);
+  static int32_t fileReadWrapper(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen);
+  static int32_t fileSeekWrapper(GIFFILE *pHandle, int32_t iPosition);
+
+  void GIFDraw(GIFDRAW *pDraw);
+  void *fileOpen(const char *filename, int32_t *pFileSize);
+  void fileClose(void *pHandle);
+  int32_t fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen);
+  int32_t fileSeek(GIFFILE *pHandle, int32_t iPosition);
+  void initializeColors();
+
+  int panelResX_;
+  int panelResY_;
+  int panelChainLength_;
+
+  MatrixPanel_I2S_DMA *display_;
+  AnimatedGIF gif_;
+  File gifFile_;
+
+  uint16_t colorRed_;
+  uint16_t colorGreen_;
+  uint16_t colorBlue_;
+  uint16_t colorWhite_;
+  uint16_t colorYellow_;
+  uint16_t colorCyan_;
+  uint16_t colorMagenta_;
+  uint16_t colorBlack_;
+};
+
+#endif // ANIMATION_MANAGER_HPP

--- a/src/EarController.cpp
+++ b/src/EarController.cpp
@@ -1,0 +1,59 @@
+#include "EarController.hpp"
+
+EarController::EarController(uint16_t ledCount, uint8_t dataPin)
+    : ledCount_(ledCount),
+      earLeds_(ledCount, dataPin, NEO_GRB + NEO_KHZ800),
+      brightness_(80),
+      red_(255),
+      green_(255),
+      blue_(255) {}
+
+bool EarController::begin() {
+  earLeds_.begin();
+  earLeds_.setBrightness(brightness_);
+  return true;
+}
+
+void EarController::setBrightness(uint8_t brightness) {
+  brightness_ = brightness;
+}
+
+uint8_t EarController::getBrightness() const {
+  return brightness_;
+}
+
+void EarController::setColor(uint8_t red, uint8_t green, uint8_t blue) {
+  red_ = red;
+  green_ = green;
+  blue_ = blue;
+}
+
+uint8_t EarController::getRed() const {
+  return red_;
+}
+
+uint8_t EarController::getGreen() const {
+  return green_;
+}
+
+uint8_t EarController::getBlue() const {
+  return blue_;
+}
+
+String EarController::getColorHexString() const {
+  String result = "#";
+  result += String(red_, 16);
+  result += String(green_, 16);
+  result += String(blue_, 16);
+  result += " ";
+  result += String(brightness_);
+  return result;
+}
+
+void EarController::update() {
+  earLeds_.setBrightness(brightness_);
+  for (uint16_t index = 0; index < ledCount_; ++index) {
+    earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(red_, green_, blue_));
+  }
+  earLeds_.show();
+}

--- a/src/EarController.hpp
+++ b/src/EarController.hpp
@@ -1,0 +1,33 @@
+#ifndef EAR_CONTROLLER_HPP
+#define EAR_CONTROLLER_HPP
+
+#include <Adafruit_NeoPixel.h>
+#include <Arduino.h>
+
+class EarController {
+public:
+  EarController(uint16_t ledCount, uint8_t dataPin);
+
+  bool begin();
+  void setBrightness(uint8_t brightness);
+  uint8_t getBrightness() const;
+
+  void setColor(uint8_t red, uint8_t green, uint8_t blue);
+  uint8_t getRed() const;
+  uint8_t getGreen() const;
+  uint8_t getBlue() const;
+
+  String getColorHexString() const;
+
+  void update();
+
+private:
+  uint16_t ledCount_;
+  Adafruit_NeoPixel earLeds_;
+  uint8_t brightness_;
+  uint8_t red_;
+  uint8_t green_;
+  uint8_t blue_;
+};
+
+#endif // EAR_CONTROLLER_HPP

--- a/src/EmotionState.cpp
+++ b/src/EmotionState.cpp
@@ -1,0 +1,36 @@
+#include "EmotionState.hpp"
+
+EmotionState::EmotionState()
+    : currentEmotion_("/neutral.gif"),
+      previousEmotion_("/neutral.gif"),
+      tiltUpEmotion_("/happy.gif"),
+      tiltSideEmotion_("/confused.gif") {}
+
+const String &EmotionState::getCurrentEmotion() const {
+  return currentEmotion_;
+}
+
+const String &EmotionState::getPreviousEmotion() const {
+  return previousEmotion_;
+}
+
+void EmotionState::setCurrentEmotion(const String &emotionName) {
+  previousEmotion_ = currentEmotion_;
+  currentEmotion_ = emotionName;
+}
+
+const String &EmotionState::getTiltUpEmotion() const {
+  return tiltUpEmotion_;
+}
+
+const String &EmotionState::getTiltSideEmotion() const {
+  return tiltSideEmotion_;
+}
+
+void EmotionState::setTiltUpEmotion(const String &emotionName) {
+  tiltUpEmotion_ = emotionName;
+}
+
+void EmotionState::setTiltSideEmotion(const String &emotionName) {
+  tiltSideEmotion_ = emotionName;
+}

--- a/src/EmotionState.hpp
+++ b/src/EmotionState.hpp
@@ -1,0 +1,28 @@
+#ifndef EMOTION_STATE_HPP
+#define EMOTION_STATE_HPP
+
+#include <Arduino.h>
+
+class EmotionState {
+public:
+  EmotionState();
+
+  const String &getCurrentEmotion() const;
+  const String &getPreviousEmotion() const;
+
+  void setCurrentEmotion(const String &emotionName);
+
+  const String &getTiltUpEmotion() const;
+  const String &getTiltSideEmotion() const;
+
+  void setTiltUpEmotion(const String &emotionName);
+  void setTiltSideEmotion(const String &emotionName);
+
+private:
+  String currentEmotion_;
+  String previousEmotion_;
+  String tiltUpEmotion_;
+  String tiltSideEmotion_;
+};
+
+#endif // EMOTION_STATE_HPP

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -1,0 +1,24 @@
+#include "FanController.hpp"
+
+FanController::FanController(uint8_t pwmPin, uint8_t channel, uint32_t frequency, uint8_t resolution)
+    : pwmPin_(pwmPin), channel_(channel), frequency_(frequency), resolution_(resolution), dutyCycle_(100) {}
+
+void FanController::begin() {
+  pinMode(pwmPin_, OUTPUT);
+  ledcSetup(channel_, frequency_, resolution_);
+  ledcAttachPin(pwmPin_, channel_);
+  ledcWrite(channel_, dutyCycle_);
+}
+
+bool FanController::setDutyCycle(int dutyCycle) {
+  if (dutyCycle < 0 || dutyCycle >= (1 << resolution_)) {
+    return false;
+  }
+  dutyCycle_ = dutyCycle;
+  ledcWrite(channel_, dutyCycle_);
+  return true;
+}
+
+int FanController::getDutyCycle() const {
+  return dutyCycle_;
+}

--- a/src/FanController.hpp
+++ b/src/FanController.hpp
@@ -1,0 +1,22 @@
+#ifndef FAN_CONTROLLER_HPP
+#define FAN_CONTROLLER_HPP
+
+#include <Arduino.h>
+
+class FanController {
+public:
+  FanController(uint8_t pwmPin, uint8_t channel, uint32_t frequency, uint8_t resolution);
+
+  void begin();
+  bool setDutyCycle(int dutyCycle);
+  int getDutyCycle() const;
+
+private:
+  uint8_t pwmPin_;
+  uint8_t channel_;
+  uint32_t frequency_;
+  uint8_t resolution_;
+  int dutyCycle_;
+};
+
+#endif // FAN_CONTROLLER_HPP

--- a/src/TiltController.cpp
+++ b/src/TiltController.cpp
@@ -1,0 +1,70 @@
+#include "TiltController.hpp"
+
+TiltController::TiltController(EmotionState &emotionState)
+    : emotionState_(emotionState),
+      tiltEnabled_(true),
+      lastUpdateMillis_(0),
+      tiltChangeMillis_(0),
+      wasTilt_(false) {}
+
+bool TiltController::begin() {
+  Wire.begin(SDA, SCL, 400000);
+  Wire.beginTransmission(0x68);
+  if (Wire.endTransmission() == 0) {
+    tiltEnabled_ = true;
+    mpu6050_ = std::make_unique<MPU6050>(Wire);
+    mpu6050_->begin();
+    return true;
+  }
+  tiltEnabled_ = false;
+  Serial.println(F("MPU6050 not found. Tilt disabled"));
+  return false;
+}
+
+void TiltController::update() {
+  if (!tiltEnabled_) {
+    return;
+  }
+
+  if (millis() - lastUpdateMillis_ < 100) {
+    return;
+  }
+
+  mpu6050_->update();
+
+  if (floatHelper_.isApproxEqual(mpu6050_->getAccX(), mpu6050_->getAccY(), mpu6050_->getAccZ(),
+                                 tiltUpX_, tiltUpY_, tiltUpZ_, tiltTolerance_) && !wasTilt_) {
+    Serial.println(F("[I] Tilt: UP!"));
+    wasTilt_ = true;
+    handleTiltChange(emotionState_.getTiltUpEmotion());
+  } else if (floatHelper_.isApproxEqual(mpu6050_->getAccX(), mpu6050_->getAccY(), mpu6050_->getAccZ(),
+                                        tiltSideX_, tiltSideY_, tiltSideZ_, tiltTolerance_) && !wasTilt_) {
+    Serial.println(F("[I] Tilt: Side!"));
+    wasTilt_ = true;
+    handleTiltChange(emotionState_.getTiltSideEmotion());
+  } else if ((wasTilt_ && (millis() - tiltChangeMillis_ > tiltAnimationMaxDuration_)) ||
+             (wasTilt_ && floatHelper_.isApproxEqual(mpu6050_->getAccX(), mpu6050_->getAccY(), mpu6050_->getAccZ(),
+                                                     tiltNeutralX_, tiltNeutralY_, tiltNeutralZ_, tiltTolerance_))) {
+    Serial.println(F("[I] Tilt: Neutral!"));
+    wasTilt_ = false;
+  }
+
+  lastUpdateMillis_ = millis();
+}
+
+bool TiltController::isEnabled() const {
+  return tiltEnabled_;
+}
+
+String TiltController::readAcceleration() {
+  if (!tiltEnabled_) {
+    return F("Tilt is disabled");
+  }
+  mpu6050_->update();
+  return String(mpu6050_->getAccX(), 2) + ";" + String(mpu6050_->getAccY(), 2) + ";" + String(mpu6050_->getAccZ(), 2);
+}
+
+void TiltController::handleTiltChange(const String &targetEmotion) {
+  emotionState_.setCurrentEmotion(targetEmotion);
+  tiltChangeMillis_ = millis();
+}

--- a/src/TiltController.cpp
+++ b/src/TiltController.cpp
@@ -12,7 +12,7 @@ bool TiltController::begin() {
   Wire.beginTransmission(0x68);
   if (Wire.endTransmission() == 0) {
     tiltEnabled_ = true;
-    mpu6050_ = std::make_unique<MPU6050>(Wire);
+    mpu6050_.reset(new MPU6050(Wire));
     mpu6050_->begin();
     return true;
   }

--- a/src/TiltController.hpp
+++ b/src/TiltController.hpp
@@ -1,0 +1,46 @@
+#ifndef TILT_CONTROLLER_HPP
+#define TILT_CONTROLLER_HPP
+
+#include <Arduino.h>
+#include <MPU6050_tockn.h>
+#include <Wire.h>
+#include <memory>
+
+#include "EmotionState.hpp"
+#include "float_helper.hpp"
+
+class TiltController {
+public:
+  explicit TiltController(EmotionState &emotionState);
+
+  bool begin();
+  void update();
+
+  bool isEnabled() const;
+  String readAcceleration();
+
+private:
+  void handleTiltChange(const String &targetEmotion);
+
+  EmotionState &emotionState_;
+  std::unique_ptr<MPU6050> mpu6050_;
+  bool tiltEnabled_;
+  unsigned long lastUpdateMillis_;
+  unsigned long tiltChangeMillis_;
+  bool wasTilt_;
+  FloatHelper floatHelper_;
+
+  const float tiltNeutralX_ = 0.3f;
+  const float tiltNeutralY_ = 0.92f;
+  const float tiltNeutralZ_ = 0.33f;
+  const float tiltSideX_ = 0.05f;
+  const float tiltSideY_ = 0.7f;
+  const float tiltSideZ_ = 0.73f;
+  const float tiltUpX_ = -0.17f;
+  const float tiltUpY_ = 0.99f;
+  const float tiltUpZ_ = 0.11f;
+  const float tiltTolerance_ = 0.1f;
+  const unsigned long tiltAnimationMaxDuration_ = 8000UL;
+};
+
+#endif // TILT_CONTROLLER_HPP

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1,0 +1,124 @@
+#include "WebServerManager.hpp"
+
+WebServerManager::WebServerManager(EmotionState &emotionState, FanController &fanController,
+                                   EarController &earController, TiltController &tiltController)
+    : server_(80),
+      emotionState_(emotionState),
+      fanController_(fanController),
+      earController_(earController),
+      tiltController_(tiltController) {}
+
+void WebServerManager::begin(const char *ssid, const char *password) {
+  WiFi.softAP(ssid, password);
+
+  registerRoutes();
+
+  ElegantOTA.begin(&server_);
+  server_.begin();
+  ElegantOTA.setAutoReboot(true);
+}
+
+void WebServerManager::loop() {
+  ElegantOTA.loop();
+}
+
+void WebServerManager::registerRoutes() {
+  server_.on("/savefile", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    if (request->hasParam("file", true) && request->hasParam("content", true)) {
+      String path = "/anims/" + request->getParam("file", true)->value();
+      File file = SPIFFS.open(path, "w");
+      if (!file) {
+        Serial.println(F("[E] There was an error opening the file for saving an animation!"));
+        file.close();
+        request->send(400, "text/plain", F("Error opening file for writing!"));
+      } else {
+        Serial.println(F("[I] File saved!"));
+        file.print(request->getParam("content", true)->value());
+        file.close();
+        request->send(200, "text/plain", F("File was saved."));
+      }
+    } else {
+      request->send(400, "text/plain", F("No valid parameters detected!"));
+    }
+  });
+
+  server_.on("/file", HTTP_DELETE, [this](AsyncWebServerRequest *request) {
+    if (request->hasParam("file")) {
+      String path = "/anims/" + request->getParam("file")->value();
+      SPIFFS.remove(path);
+      request->send(200, "text/plain", F("File was deleted."));
+    } else {
+      request->send(400, "text/plain", F("Parameter 'file' not present!"));
+    }
+  });
+
+  server_.on("/emotion", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", emotionState_.getCurrentEmotion());
+  });
+
+  server_.on("/emotion", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+    if (request->hasParam("name", true)) {
+      emotionState_.setCurrentEmotion(request->getParam("name", true)->value());
+      request->send(200, "text/plain", F("Emotion changed."));
+    } else {
+      request->send(400, "text/plain", F("No valid parameters detected!"));
+    }
+  });
+
+  server_.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", String(ESP.getFreeHeap()));
+  });
+
+  server_.on("/fan", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", String(fanController_.getDutyCycle()));
+  });
+
+  server_.on("/fan", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+    if (request->hasParam("duty", true)) {
+      int duty = request->getParam("duty", true)->value().toInt();
+      if (fanController_.setDutyCycle(duty)) {
+        request->send(200, "text/plain", "Set PWM to: " + String(fanController_.getDutyCycle()));
+        return;
+      }
+    }
+    request->send(400, "text/plain", F("Invalid duty cycle"));
+  });
+
+  server_.on("/ears", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", earController_.getColorHexString());
+  });
+
+  server_.on("/ears", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+    if (request->hasParam("color", true)) {
+      String color = request->getParam("color", true)->value();
+      int r = 0, g = 0, b = 0;
+      int itemsFound = sscanf(color.c_str(), "#%02x%02x%02x", &r, &g, &b);
+      if (itemsFound != 3) {
+        request->send(400, "text/plain", F("Could not set color use #FFFFFF format."));
+        return;
+      }
+      earController_.setColor(static_cast<uint8_t>(r), static_cast<uint8_t>(g), static_cast<uint8_t>(b));
+    }
+    if (request->hasParam("brightness", true)) {
+      int brightness = request->getParam("brightness", true)->value().toInt();
+      if (brightness >= 256 || brightness < 0) {
+        request->send(400, "text/plain", F("Could not set brightness use 0-255 value."));
+        return;
+      }
+      earController_.setBrightness(static_cast<uint8_t>(brightness));
+    }
+    request->send(200, "text/plain", F("Color/brightness set."));
+  });
+
+  server_.on("/gyro", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!tiltController_.isEnabled()) {
+      request->send(200, "text/plain", F("Tilt is disabled"));
+      return;
+    }
+    request->send(200, "text/plain", tiltController_.readAcceleration());
+  });
+
+  server_.onNotFound([](AsyncWebServerRequest *request) {
+    request->send(404, "text/plain", "Not found");
+  });
+}

--- a/src/WebServerManager.hpp
+++ b/src/WebServerManager.hpp
@@ -1,0 +1,34 @@
+#ifndef WEB_SERVER_MANAGER_HPP
+#define WEB_SERVER_MANAGER_HPP
+
+#include <ESPAsyncWebServer.h>
+#include <ElegantOTA.h>
+#include <SPIFFS.h>
+#include <WiFi.h>
+
+#include <Arduino.h>
+
+#include "EarController.hpp"
+#include "EmotionState.hpp"
+#include "FanController.hpp"
+#include "TiltController.hpp"
+
+class WebServerManager {
+public:
+  WebServerManager(EmotionState &emotionState, FanController &fanController,
+                   EarController &earController, TiltController &tiltController);
+
+  void begin(const char *ssid, const char *password);
+  void loop();
+
+private:
+  void registerRoutes();
+
+  AsyncWebServer server_;
+  EmotionState &emotionState_;
+  FanController &fanController_;
+  EarController &earController_;
+  TiltController &tiltController_;
+};
+
+#endif // WEB_SERVER_MANAGER_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,477 +1,63 @@
-#include <Wire.h>
-#include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
-#include <SPIFFS.h>
-#include <AnimatedGIF.h>
-#include "WiFi.h"
-#include "ESPAsyncWebServer.h"
-#include <ElegantOTA.h>
-#include <MPU6050_tockn.h>
-#include <Adafruit_NeoPixel.h>
+#include <Arduino.h>
 
-#include "float_helper.hpp"
-#include "Arduino.h"
+#include "AnimationManager.hpp"
+#include "EarController.hpp"
+#include "EmotionState.hpp"
+#include "FanController.hpp"
+#include "TiltController.hpp"
+#include "WebServerManager.hpp"
 
-// Display config
+// Display configuration
+constexpr int PANEL_RES_X = 64;
+constexpr int PANEL_RES_Y = 32;
+constexpr int PANEL_CHAIN = 2;
 
-const int panelResX = 64;  // Number of pixels wide of each INDIVIDUAL panel module.
-const int panelResY = 32;  // Number of pixels tall of each INDIVIDUAL panel module.
-const int panel_chain = 2; // Total number of panels chained one to another.
+// Wi-Fi configuration
+const char *WIFI_NAME = "Proto";
+const char *WIFI_PASS = "Test123456!";
 
-MatrixPanel_I2S_DMA *dma_display = nullptr;
+// Fan configuration
+constexpr uint8_t FAN_PWM_PIN = 32;
+constexpr uint8_t FAN_PWM_CHANNEL = 0;
+constexpr uint32_t FAN_PWM_FREQUENCY = 25000;
+constexpr uint8_t FAN_PWM_RESOLUTION = 8;
 
-uint16_t myRED = dma_display->color565(255, 0, 0);
-uint16_t myGREEN = dma_display->color565(0, 255, 0);
-uint16_t myBLUE = dma_display->color565(0, 0, 255);
-uint16_t myWHITE = dma_display->color565(255, 255, 255);
-uint16_t myYELLOW = dma_display->color565(255, 255, 0);
-uint16_t myCYAN = dma_display->color565(0, 255, 255);
-uint16_t myMAGENTA = dma_display->color565(255, 0, 255);
-uint16_t myBLACK = dma_display->color565(0, 0, 0);
+// Ear LED configuration
+constexpr uint16_t LEDS_PER_DISPLAY = 24;
+constexpr uint8_t DATA_PIN_EARS = 33;
 
-// Gifs
+EmotionState emotionState;
+FanController fanController(FAN_PWM_PIN, FAN_PWM_CHANNEL, FAN_PWM_FREQUENCY, FAN_PWM_RESOLUTION);
+EarController earController(LEDS_PER_DISPLAY, DATA_PIN_EARS);
+TiltController tiltController(emotionState);
+AnimationManager animationManager(PANEL_RES_X, PANEL_RES_Y, PANEL_CHAIN);
+WebServerManager webServerManager(emotionState, fanController, earController, tiltController);
 
-AnimatedGIF gif;
-File gifFile;
-static uint16_t gifPaletteRGB565[256];
-
-// Wifi
-const char *wifiName = "Proto";       // Number of pixels wide of each INDIVIDUAL panel module.
-const char *wifiPass = "Test123456!"; // Number of pixels tall of each INDIVIDUAL panel module.
-
-AsyncWebServer server(80);
-
-// Fan
-#define fanPWM 32 // PWM pin to control the fan
-int fanDutyCycle = 100;
-
-// Emotions
-String currentEmotionGifName = "/neutral.gif";
-String previousEmotionGifName = "/neutral.gif";
-
-// Eccelerometer
-MPU6050 *mpu6050;
-FloatHelper float_helper;
-
-// Tilt
-String tiltUpEmotionGifName = "/happy.gif";
-String tiltSideEmotionGifName = "/confused.gif";
-
-bool tiltEnabled = true;
-int tiltAnimationMaxDuration = 8000;
-
-float tiltNeutralX = 0.3;
-float tiltNeutralY = 0.92;
-float tiltNeutralZ = 0.33;
-float tiltSideX = 0.05;
-float tiltSideY = 0.7;
-float tiltSideZ = 0.73;
-float tiltUpX = -0.17;
-float tiltUpY = 0.99;
-float tiltUpZ = 0.11;
-float tiltTolerance = 0.1;
-
-// NeoPixel
-#define LEDS_PER_DISPLAY 24
-#define DATA_PIN_EARS 33
-int earsBrightness = 80;
-int earsColorRed = 255;
-int earsColorGreen = 255;
-int earsColorBlue = 255;
-Adafruit_NeoPixel earLeds(LEDS_PER_DISPLAY, DATA_PIN_EARS, NEO_GRB + NEO_KHZ800);
-
-//--------------------------------//WiFi server setup
-void startWiFiWeb()
-{
-  WiFi.softAP(wifiName, wifiPass);
-
-  server.on("/savefile", HTTP_POST, [](AsyncWebServerRequest *request) { // saves data from POST to file
-    if (request->hasParam("file", true) && request->hasParam("content", true))
-    {
-      File file = SPIFFS.open("/anims/" + request->getParam("file", true)->value(), "w");
-      if (!file)
-      {
-        Serial.println(F("[E] There was an error opening the file for saving an animation!"));
-        file.close();
-        request->send(400, "text/plain", F("Error opening file for writing!"));
-      }
-      else
-      {
-        Serial.println(F("[I] File saved!"));
-        file.print(request->getParam("content", true)->value());
-        file.close();
-        request->send(200, "text/plain", F("File was saved."));
-      }
-    }
-    else
-    {
-      request->send(400, "text/plain", F("No valid parameters detected!"));
-    }
-  });
-
-  server.on("/file", HTTP_DELETE, [](AsyncWebServerRequest *request)
-            { 
-    if(request->hasParam("file")) {
-      SPIFFS.remove("/anims/"+request->getParam("file")->value());
-      request->send(200, "text/plain", F("File was deleted."));
-    } else {
-      request->send(400, "text/plain", F("Parameter 'file' not present!"));
-    } });
-
-  server.on("/emotion", HTTP_GET, [](AsyncWebServerRequest *request)
-            { request->send(200, "text/plain", currentEmotionGifName); });
-
-  server.on("/emotion", HTTP_PUT, [](AsyncWebServerRequest *request)
-            {
-    if(request->hasParam("name", true)) {
-      previousEmotionGifName = currentEmotionGifName;
-      currentEmotionGifName = String(request->getParam("name", true)->value());
-      request->send(200, "text/plain", F("Emotion changed."));
-    } else {
-      request->send(400, "text/plain", F("No valid parameters detected!"));
-    } });
-
-  server.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request)
-            { request->send(200, "text/plain", String(ESP.getFreeHeap())); });
-
-  server.on("/fan", HTTP_GET, [](AsyncWebServerRequest *request)
-            { request->send(200, "text/plain", String(fanDutyCycle)); });
-
-  server.on("/fan", HTTP_PUT, [](AsyncWebServerRequest *request)
-            { 
-               if(request->hasParam("duty", true)) {
-                int duty = request->getParam("duty", true)->value().toInt();
-                if(duty < 256 && duty >= 0) {
-                  ledcWrite(0, duty);
-                  fanDutyCycle = duty;
-                  request->send(200, "text/plain", "Set PWM to: " + String(fanDutyCycle));
-                  return;
-                }
-              }
-              request->send(400, "text/plain", F("Invalid duty cycle"));
-            });
-
-  server.on("/ears", HTTP_GET, [](AsyncWebServerRequest *request)
-            { 
-              char colorHex[20];
-              request->send(
-                200,
-                 "text/plain", 
-                 "#"+String(earsColorRed,16)+String(earsColorGreen,16)+String(earsColorBlue,16)+" "+String(earsBrightness)); 
-            });
-            
-  server.on("/ears", HTTP_PUT, [](AsyncWebServerRequest *request)
-            { 
-              if(request->hasParam("color", true)) {
-                String color = request->getParam("color", true)->value();
-                int r,g,b =0;
-                int itemsFound = sscanf(color.c_str(), "#%02x%02x%02x", &r, &g, &b);
-                if(itemsFound != 3){
-                  request->send(400, "text/plain", F("Could not set color use #FFFFFF format."));
-                  return;
-                }
-                earsColorRed = r;
-                earsColorGreen = g;
-                earsColorBlue = b;
-              }
-              if(request->hasParam("brightness", true)) {
-                int brightness = request->getParam("brightness", true)->value().toInt();
-                if(brightness >= 256 || brightness < 0) {
-                  request->send(400, "text/plain", F("Could not set brightness use 0-255 value."));
-                  return;
-                }
-                earsBrightness = brightness;
-              }
-              request->send(200, "text/plain", "Color/brightness set."); 
-            });
-
-  server.on("/gyro", HTTP_GET, [](AsyncWebServerRequest *request)
-            { 
-              if(!tiltEnabled){
-                request->send(200, "text/plain", F("Tilt is disabled")); 
-                return;
-              }
-              mpu6050->update();
-              request->send(200, "text/plain", String(mpu6050->getAccX(), 2) + ";" + String(mpu6050->getAccY(), 2) + ";" + String(mpu6050->getAccZ(), 2)); 
-            });
-
-  server.onNotFound([](AsyncWebServerRequest *request)
-                    { request->send(404, "text/plain", "Not found"); });
-  ElegantOTA.begin(&server);
-  server.begin();
-
-  ElegantOTA.setAutoReboot(true);
-}
-
-unsigned long lastMillsTilt = 0, tiltChange = 0;
-bool wasTilt, tiltInitDone = false;
-
-void processTilt()
-{
-  if (lastMillsTilt + 100 > millis() || !tiltEnabled)
-  {
-    return;
-  }
-
-  mpu6050->update();
-
-  if (float_helper.isApproxEqual(mpu6050->getAccX(), mpu6050->getAccY(), mpu6050->getAccZ(), tiltUpX, tiltUpY, tiltUpZ, tiltTolerance) && !wasTilt)
-  {
-    Serial.println(F("[I] Tilt: UP!"));
-    wasTilt = true;
-    previousEmotionGifName = currentEmotionGifName;
-    currentEmotionGifName = tiltUpEmotionGifName;
-    tiltChange = millis();
-  }
-  else if (float_helper.isApproxEqual(mpu6050->getAccX(), mpu6050->getAccY(), mpu6050->getAccZ(), tiltSideX, tiltSideY, tiltSideZ, tiltTolerance) && !wasTilt)
-  {
-    Serial.println(F("[I] Tilt: Side!"));
-    wasTilt = true;
-    previousEmotionGifName = currentEmotionGifName;
-    currentEmotionGifName = tiltSideEmotionGifName;
-    tiltChange = millis();
-  }
-  else if ((tiltChange + tiltAnimationMaxDuration < millis() || float_helper.isApproxEqual(mpu6050->getAccX(), mpu6050->getAccY(), mpu6050->getAccZ(), tiltNeutralX, tiltNeutralY, tiltNeutralZ, tiltTolerance)) && wasTilt)
-  {
-    Serial.println(F("[I] Tilt: Neutral!"));
-    wasTilt = false;
-  }
-  lastMillsTilt = millis();
-}
-
-void setupMatrices()
-{
-  HUB75_I2S_CFG mxconfig(
-      panelResX,  // Module width
-      panelResY,  // Module height
-      panel_chain // Chain length
-  );
-
-  mxconfig.gpio.e = 18;
-  mxconfig.clkphase = false;
-
-  dma_display = new MatrixPanel_I2S_DMA(mxconfig);
-  dma_display->begin();
-
-  dma_display->fillScreen(myBLACK);
-  dma_display->setCursor(5, 0);
-  dma_display->setTextColor(myBLUE);
-  dma_display->println("Startup...");
-}
-
-void GIFDraw(GIFDRAW *pDraw)
-{
-  uint8_t *s;
-  uint16_t *d, *usPalette, usTemp[320];
-  int x, y, iWidth;
-
-  usPalette = pDraw->pPalette;
-  y = pDraw->iY + pDraw->y; // current line
-
-  s = pDraw->pPixels;
-  if (pDraw->ucDisposalMethod == 2) // restore to background color
-  {
-    for (x = 0; x < iWidth; x++)
-    {
-      if (s[x] == pDraw->ucTransparent)
-        s[x] = pDraw->ucBackground;
-    }
-    pDraw->ucHasTransparency = 0;
-  }
-  // Apply the new pixels to the main image
-  if (pDraw->ucHasTransparency) // if transparency used
-  {
-    uint8_t *pEnd, c, ucTransparent = pDraw->ucTransparent;
-    int x, iCount;
-    pEnd = s + pDraw->iWidth;
-    x = 0;
-    iCount = 0; // count non-transparent pixels
-    while (x < pDraw->iWidth)
-    {
-      c = ucTransparent - 1;
-      d = usTemp;
-      while (c != ucTransparent && s < pEnd)
-      {
-        c = *s++;
-        if (c == ucTransparent) // done, stop
-        {
-          s--; // back up to treat it like transparent
-        }
-        else // opaque
-        {
-          *d++ = usPalette[c];
-          iCount++;
-        }
-      } // while looking for opaque pixels
-      if (iCount) // any opaque pixels?
-      {
-        for (int xOffset = 0; xOffset < iCount; xOffset++)
-        {
-          dma_display->drawPixel(x + xOffset + pDraw->iX, y, usTemp[xOffset]);
-        }
-        x += iCount;
-        iCount = 0;
-      }
-      // no, look for a run of transparent pixels
-      c = ucTransparent;
-      while (c == ucTransparent && s < pEnd)
-      {
-        c = *s++;
-        if (c == ucTransparent)
-          iCount++;
-        else
-          s--;
-      }
-      if (iCount)
-      {
-        x += iCount; // skip these
-        iCount = 0;
-      }
-    }
-  }
-  else
-  {
-    s = pDraw->pPixels;
-    // Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
-    for (x = 0; x < pDraw->iWidth; x++)
-    {
-      dma_display->drawPixel(x + pDraw->iX, y, usPalette[*s++]);
-    }
-  }
-} /* GIFDraw() */
-
-void *fileOpen(const char *filename, int32_t *pFileSize)
-{
-  gifFile = SPIFFS.open(filename, FILE_READ);
-  if (!gifFile)
-  {
-    Serial.printf("Failed to open GIF file from SPIFFS: %s\n", filename);
-    *pFileSize = 0;
-    return NULL;
-  }
-  *pFileSize = gifFile.size();
-  return (void *)&gifFile;
-}
-
-void fileClose(void *pHandle)
-{
-  (void)pHandle;
-  if (gifFile)
-    gifFile.close();
-}
-
-int32_t fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen)
-{
-  (void)pHandle;
-  if (!gifFile)
-    return 0;
-  int32_t r = gifFile.read(pBuf, (size_t)iLen);
-  return r;
-}
-
-int32_t fileSeek(GIFFILE *pHandle, int32_t iPosition)
-{
-  (void)pHandle;
-  if (!gifFile)
-    return -1;
-  if (iPosition < 0)
-    iPosition = 0;
-  if (iPosition > (int32_t)gifFile.size())
-    iPosition = gifFile.size();
-  gifFile.seek(iPosition, SeekSet);
-  return iPosition;
-}
-
-void listSPIFFS()
-{
-  Serial.println("SPIFFS contents:");
-  File root = SPIFFS.open("/");
-  if (!root)
-  {
-    Serial.println("Failed to open root directory");
-    return;
-  }
-  if (!root.isDirectory())
-  {
-    Serial.println("Root is not a directory");
-    return;
-  }
-
-  File file = root.openNextFile();
-  while (file)
-  {
-    Serial.printf("  %s  (%d bytes)\n", file.name(), file.size());
-    file = root.openNextFile();
-  }
-  Serial.println("---- End of SPIFFS listing ----");
-}
-
-void setupTilt()
-{
-  Wire.begin(SDA, SCL, 400000);
-  Wire.beginTransmission (0x68);
-  if (Wire.endTransmission () == 0) {
-    tiltEnabled = true;
-    mpu6050 = new MPU6050(Wire);
-    mpu6050->begin();
-  } else{
-    tiltEnabled = false;
-    Serial.println("MPU6050 not found. Tilt disabled");
-  }
-}
-
-void setupFan()
-{
-  pinMode(fanPWM, OUTPUT);
-
-  ledcSetup(0, 25000, 8);
-  ledcAttachPin(fanPWM, 0);
-  ledcWrite(0, fanDutyCycle);
-}
-
-void setup()
-{
+void setup() {
   Serial.begin(115200);
 
-  setupTilt();
-  setupMatrices();
-  setupFan();
+  tiltController.begin();
 
-  if(!earLeds.begin()){
-    Serial.println("Starting LED driver failed");
-  }
-  earLeds.setBrightness(earsBrightness);
-  
-  if (!SPIFFS.begin(true))
-  { // use true to format if needed
-    Serial.println("SPIFFS mount failed!");
-    while (true)
+  if (!animationManager.begin()) {
+    while (true) {
       delay(1000);
+    }
   }
-  Serial.println("SPIFFS mounted.");
 
-  gif.begin(LITTLE_ENDIAN_PIXELS);
+  fanController.begin();
 
-  listSPIFFS();
-  startWiFiWeb();
+  if (!earController.begin()) {
+    Serial.println(F("Starting LED driver failed"));
+  }
 
-  Serial.println("Init done");
+  webServerManager.begin(WIFI_NAME, WIFI_PASS);
+
+  Serial.println(F("Init done"));
 }
 
-void loop()
-{
-  ElegantOTA.loop();
-  processTilt();
-
-  if (gif.open(currentEmotionGifName.c_str(), fileOpen, fileClose, fileRead, fileSeek, GIFDraw))
-  {
-    //Serial.printf("Successfully opened GIF; Canvas size = %d x %d\n", gif.getCanvasWidth(), gif.getCanvasHeight());
-    gif.playFrame(true, NULL);
-    gif.close();
-  }
-  earLeds.setBrightness(earsBrightness);
-  for (int8_t index = 0; index < LEDS_PER_DISPLAY; index++)
-  {
-    earLeds.setPixelColor(index, Adafruit_NeoPixel::Color(earsColorRed, earsColorGreen, earsColorBlue));
-  }
-  earLeds.show(); 
+void loop() {
+  webServerManager.loop();
+  tiltController.update();
+  animationManager.playEmotion(emotionState.getCurrentEmotion());
+  earController.update();
 }


### PR DESCRIPTION
## Summary
- split the previous monolithic firmware into AnimationManager, WebServerManager, FanController, EarController, TiltController, and EmotionState classes
- refactor setup and loop to initialize and coordinate the new modules while preserving existing behaviour

## Testing
- platformio run *(fails: command not found: platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68d14f124d44832d9467e73225db5176