### PR TITLE
Add SH1106 status display module

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,22 +9,22 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-trinity]
-platform = espressif32 @ 6.8.0 
+platform = espressif32 @ 6.8.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
 board_build.filesystem = spiffs
 build_flags = 
 	-DCORE_DEBUG_LEVEL=1
-    -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
-lib_deps =
-    AnimatedGIF
-    https://github.com/adafruit/Adafruit-GFX-Library.git
-    https://github.com/adafruit/Adafruit_SH1106.git
-        https://github.com/tockn/MPU6050_tockn
-    https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git
-    ESP32Async/AsyncTCP@3.3.8
+	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+lib_deps = 
+	AnimatedGIF
+	https://github.com/adafruit/Adafruit-GFX-Library.git
+	https://github.com/tockn/MPU6050_tockn
+	https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git
+	ESP32Async/AsyncTCP@3.3.8
 	ESP32Async/ESPAsyncWebServer@3.7.4
 	ayushsharma82/ElegantOTA@3.1.7
-    https://github.com/adafruit/Adafruit_NeoPixel.git
+	https://github.com/adafruit/Adafruit_NeoPixel.git
+	aki237/Adafruit_ESP32_SH1106@^1.0.2
     bblanchon/ArduinoJson@^7.0.3

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,10 +17,11 @@ board_build.filesystem = spiffs
 build_flags = 
 	-DCORE_DEBUG_LEVEL=1
     -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
-lib_deps = 
+lib_deps =
     AnimatedGIF
     https://github.com/adafruit/Adafruit-GFX-Library.git
-	https://github.com/tockn/MPU6050_tockn
+    https://github.com/adafruit/Adafruit_SH1106.git
+        https://github.com/tockn/MPU6050_tockn
     https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git
     ESP32Async/AsyncTCP@3.3.8
 	ESP32Async/ESPAsyncWebServer@3.7.4

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -22,3 +22,7 @@ bool FanController::setDutyCycle(int dutyCycle) {
 int FanController::getDutyCycle() const {
   return dutyCycle_;
 }
+
+int FanController::getMaxDutyCycle() const {
+  return (1 << resolution_) - 1;
+}

--- a/src/FanController.hpp
+++ b/src/FanController.hpp
@@ -10,6 +10,7 @@ public:
   void begin();
   bool setDutyCycle(int dutyCycle);
   int getDutyCycle() const;
+  int getMaxDutyCycle() const;
 
 private:
   uint8_t pwmPin_;

--- a/src/StatusDisplay.cpp
+++ b/src/StatusDisplay.cpp
@@ -1,0 +1,159 @@
+#include "StatusDisplay.hpp"
+
+#include "EarController.hpp"
+#include "EmotionState.hpp"
+#include "FanController.hpp"
+
+#include <WiFi.h>
+#include <Wire.h>
+#include <stdio.h>
+
+namespace {
+
+// Simple 16x16 monochrome icons stored in program memory to minimize RAM use.
+const uint8_t FAN_ICON_16X16[] PROGMEM = {
+    0x00, 0x00, 0x07, 0xE0, 0x1F, 0xF8, 0x3C, 0x3C,
+    0x78, 0x1E, 0x70, 0x0E, 0xE3, 0x37, 0xC7, 0xF3,
+    0xCD, 0x87, 0xE6, 0x0F, 0x70, 0x0E, 0x78, 0x1E,
+    0x3C, 0x3C, 0x1F, 0xF8, 0x07, 0xE0, 0x00, 0x00,
+};
+
+const uint8_t WIFI_ICON_16X16[] PROGMEM = {
+    0x07, 0xE0, 0x1C, 0x38, 0x30, 0x0C, 0x00, 0x00,
+    0x03, 0xC0, 0x06, 0x30, 0x00, 0x00, 0x00, 0xC0,
+    0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0xC0,
+    0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+constexpr int kIconWidth = 16;
+constexpr int kIconHeight = 16;
+constexpr int kTextIndent = kIconWidth + 2;
+
+} // namespace
+
+StatusDisplay::StatusDisplay(EmotionState &emotionState,
+                             FanController &fanController,
+                             EarController &earController,
+                             int8_t resetPin,
+                             uint8_t i2cAddress)
+    : emotionState_(emotionState),
+      fanController_(fanController),
+      earController_(earController),
+      display_(resetPin),
+      i2cAddress_(i2cAddress),
+      lastUpdateMs_(0),
+      updateIntervalMs_(1000),
+      lastEmotion_(),
+      lastDutyCycle_(-1),
+      lastRed_(0),
+      lastGreen_(0),
+      lastBlue_(0),
+      lastBrightness_(0),
+      lastApIp_() {}
+
+bool StatusDisplay::begin() {
+  Wire.begin();
+
+  if (!display_.begin(SH1106_SWITCHCAPVCC, i2cAddress_)) {
+    Serial.println(F("Failed to initialize SH1106 display"));
+    return false;
+  }
+
+  display_.clearDisplay();
+  display_.display();
+
+  drawStatus(true);
+  return true;
+}
+
+void StatusDisplay::update() {
+  const uint32_t now = millis();
+  if (now - lastUpdateMs_ < updateIntervalMs_) {
+    return;
+  }
+  lastUpdateMs_ = now;
+  drawStatus();
+}
+
+void StatusDisplay::setUpdateInterval(uint32_t intervalMs) {
+  updateIntervalMs_ = intervalMs;
+}
+
+void StatusDisplay::drawStatus(bool force) {
+  const String &currentEmotion = emotionState_.getCurrentEmotion();
+  const int currentDutyCycle = fanController_.getDutyCycle();
+  const uint8_t currentRed = earController_.getRed();
+  const uint8_t currentGreen = earController_.getGreen();
+  const uint8_t currentBlue = earController_.getBlue();
+  const uint8_t currentBrightness = earController_.getBrightness();
+  const String currentApIp = getAccessPointIp();
+
+  if (!force && currentEmotion == lastEmotion_ && currentDutyCycle == lastDutyCycle_ &&
+      currentRed == lastRed_ && currentGreen == lastGreen_ && currentBlue == lastBlue_ &&
+      currentBrightness == lastBrightness_ && currentApIp == lastApIp_) {
+    return;
+  }
+
+  display_.clearDisplay();
+  display_.setTextSize(1);
+  display_.setTextColor(WHITE);
+
+  display_.setCursor(kTextIndent, 0);
+  display_.print(F("Anim: "));
+  display_.println(currentEmotion);
+
+  display_.drawBitmap(0, 12, FAN_ICON_16X16, kIconWidth, kIconHeight, WHITE);
+  display_.setCursor(kTextIndent, 12);
+  display_.print(F("Fan: "));
+  display_.print(formatFanSpeedPercent(currentDutyCycle));
+  display_.println(F("%"));
+
+  display_.setCursor(0, 28);
+  display_.print(F("Color: "));
+  display_.println(formatEarColor(currentRed, currentGreen, currentBlue));
+
+  display_.setCursor(0, 40);
+  display_.print(F("Bright: "));
+  display_.println(currentBrightness);
+
+  display_.drawBitmap(0, 48, WIFI_ICON_16X16, kIconWidth, kIconHeight, WHITE);
+  display_.setCursor(kTextIndent, 48);
+  display_.print(F("WiFi: "));
+  display_.println(currentApIp);
+
+  display_.display();
+
+  lastEmotion_ = currentEmotion;
+  lastDutyCycle_ = currentDutyCycle;
+  lastRed_ = currentRed;
+  lastGreen_ = currentGreen;
+  lastBlue_ = currentBlue;
+  lastBrightness_ = currentBrightness;
+  lastApIp_ = currentApIp;
+}
+
+String StatusDisplay::formatFanSpeedPercent(int dutyCycle) const {
+  const int maxDutyCycle = fanController_.getMaxDutyCycle();
+  if (maxDutyCycle <= 0) {
+    return String("0");
+  }
+
+  const float percent = (static_cast<float>(dutyCycle) / static_cast<float>(maxDutyCycle)) * 100.0f;
+  const int roundedPercent = static_cast<int>(percent + 0.5f);
+
+  return String(roundedPercent);
+}
+
+String StatusDisplay::formatEarColor(uint8_t red, uint8_t green, uint8_t blue) const {
+  char buffer[8];
+  snprintf(buffer, sizeof(buffer), "#%02X%02X%02X", red, green, blue);
+  return String(buffer);
+}
+
+String StatusDisplay::getAccessPointIp() const {
+  IPAddress apIp = WiFi.softAPIP();
+  if (!apIp) {
+    return String(F("0.0.0.0"));
+  }
+  return apIp.toString();
+}

--- a/src/StatusDisplay.cpp
+++ b/src/StatusDisplay.cpp
@@ -54,10 +54,7 @@ StatusDisplay::StatusDisplay(EmotionState &emotionState,
 bool StatusDisplay::begin() {
   Wire.begin();
 
-  if (!display_.begin(SH1106_SWITCHCAPVCC, i2cAddress_)) {
-    Serial.println(F("Failed to initialize SH1106 display"));
-    return false;
-  }
+  display_.begin(SH1106_SWITCHCAPVCC, i2cAddress_);
 
   display_.clearDisplay();
   display_.display();

--- a/src/StatusDisplay.hpp
+++ b/src/StatusDisplay.hpp
@@ -1,0 +1,50 @@
+#ifndef STATUS_DISPLAY_HPP
+#define STATUS_DISPLAY_HPP
+
+#ifndef SH1106_128_64
+#define SH1106_128_64
+#endif
+
+#include <Adafruit_SH1106.h>
+#include <Arduino.h>
+
+class EmotionState;
+class FanController;
+class EarController;
+
+class StatusDisplay {
+public:
+  StatusDisplay(EmotionState &emotionState,
+                FanController &fanController,
+                EarController &earController,
+                int8_t resetPin = -1,
+                uint8_t i2cAddress = 0x3C);
+
+  bool begin();
+  void update();
+  void setUpdateInterval(uint32_t intervalMs);
+
+private:
+  void drawStatus(bool force = false);
+  String formatFanSpeedPercent(int dutyCycle) const;
+  String formatEarColor(uint8_t red, uint8_t green, uint8_t blue) const;
+  String getAccessPointIp() const;
+
+  EmotionState &emotionState_;
+  FanController &fanController_;
+  EarController &earController_;
+  Adafruit_SH1106 display_;
+  uint8_t i2cAddress_;
+  uint32_t lastUpdateMs_;
+  uint32_t updateIntervalMs_;
+
+  String lastEmotion_;
+  int lastDutyCycle_;
+  uint8_t lastRed_;
+  uint8_t lastGreen_;
+  uint8_t lastBlue_;
+  uint8_t lastBrightness_;
+  String lastApIp_;
+};
+
+#endif // STATUS_DISPLAY_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "EarController.hpp"
 #include "EmotionState.hpp"
 #include "FanController.hpp"
+#include "StatusDisplay.hpp"
 #include "TiltController.hpp"
 #include "WebServerManager.hpp"
 
@@ -26,12 +27,17 @@ constexpr uint8_t FAN_PWM_RESOLUTION = 8;
 constexpr uint16_t LEDS_PER_DISPLAY = 24;
 constexpr uint8_t DATA_PIN_EARS = 33;
 
+// Status display configuration
+constexpr int8_t DISPLAY_RESET_PIN = -1;
+constexpr uint8_t DISPLAY_I2C_ADDRESS = 0x3C;
+
 EmotionState emotionState;
 FanController fanController(FAN_PWM_PIN, FAN_PWM_CHANNEL, FAN_PWM_FREQUENCY, FAN_PWM_RESOLUTION);
 EarController earController(LEDS_PER_DISPLAY, DATA_PIN_EARS);
 TiltController tiltController(emotionState);
 AnimationManager animationManager(PANEL_RES_X, PANEL_RES_Y, PANEL_CHAIN);
 WebServerManager webServerManager(emotionState, fanController, earController, tiltController);
+StatusDisplay statusDisplay(emotionState, fanController, earController, DISPLAY_RESET_PIN, DISPLAY_I2C_ADDRESS);
 
 void setup() {
   Serial.begin(115200);
@@ -50,6 +56,10 @@ void setup() {
     Serial.println(F("Starting LED driver failed"));
   }
 
+  if (!statusDisplay.begin()) {
+    Serial.println(F("Starting status display failed"));
+  }
+
   webServerManager.begin(WIFI_NAME, WIFI_PASS);
 
   Serial.println(F("Init done"));
@@ -60,4 +70,5 @@ void loop() {
   tiltController.update();
   animationManager.playEmotion(emotionState.getCurrentEmotion());
   earController.update();
+  statusDisplay.update();
 }


### PR DESCRIPTION
## Summary
- add a reusable StatusDisplay module that renders the current animation, fan speed, and ear LED status on an SH1106 I2C panel
- integrate the status display into the main application and add the required SH1106 library dependency
- expose the maximum duty cycle from FanController to support percentage formatting on the display output
- surface the access point IP address and show fan/WiFi icons on the status display alongside the existing telemetry

## Testing
- not run (PlatformIO CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6821f1878832d848785e241424e8c