### PR TITLE
Fix binary animation upload handling

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -552,21 +552,26 @@
           setText(uploadStatus, "Please choose a file.");
           return;
         }
+
         var file = fileInput.files[0];
         var name = fileNameInput.value.trim() || file.name;
         if (!name) {
           setText(uploadStatus, "File name is required.");
           return;
         }
-        file.text().then(function (content) {
-          var body = new URLSearchParams({ file: name, content: content });
-          return fetchText("/file", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded" },
-            body: body
-          });
+
+        var formData = new FormData();
+        formData.append("name", name);
+        formData.append("file", file, name);
+
+        setText(uploadStatus, "Uploading...");
+
+        fetchText("/file", {
+          method: "POST",
+          body: formData
         }).then(function (text) {
           setText(uploadStatus, text);
+          uploadForm.reset();
           refreshFiles();
         }).catch(function (error) {
           setText(uploadStatus, "Error: " + error.message);

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -3,6 +3,45 @@
 #include <vector>
 #include <ArduinoJson.h>
 
+namespace {
+struct UploadContext {
+  String tempPath;
+  String finalPath;
+  bool error = false;
+};
+
+String sanitizeFileName(String name) {
+  name.trim();
+
+  String sanitized;
+  sanitized.reserve(name.length());
+  for (size_t i = 0; i < name.length(); ++i) {
+    char c = name.charAt(i);
+    bool allowed = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                   (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.';
+    if (allowed) {
+      sanitized += c;
+    }
+  }
+
+  if (sanitized.length() == 0) {
+    sanitized = F("animation");
+  }
+
+  String lower = sanitized;
+  lower.toLowerCase();
+  if (!lower.endsWith(F(".gif"))) {
+    sanitized += F(".gif");
+  }
+
+  if (sanitized.length() > 0 && sanitized.charAt(0) == '.') {
+    sanitized = String(F("animation")) + sanitized;
+  }
+
+  return sanitized;
+}
+} // namespace
+
 WebServerManager::WebServerManager(EmotionState &emotionState, FanController &fanController,
                                    EarController &earController, TiltController &tiltController)
     : server_(80),
@@ -28,24 +67,33 @@ void WebServerManager::loop() {
 void WebServerManager::registerRoutes() {
   server_.serveStatic("/", SPIFFS, "/").setDefaultFile("index.html");
 
-  server_.on("/file", HTTP_POST, [this](AsyncWebServerRequest *request) {
-    if (request->hasParam("file", true) && request->hasParam("content", true)) {
-      String path = "/anims/" + request->getParam("file", true)->value();
-      File file = SPIFFS.open(path, "w");
-      if (!file) {
-        Serial.println(F("[E] There was an error opening the file for saving an animation!"));
-        file.close();
-        request->send(400, "text/plain", F("Error opening file for writing!"));
-      } else {
-        Serial.println(F("[I] File saved!"));
-        file.print(request->getParam("content", true)->value());
-        file.close();
-        request->send(200, "text/plain", F("File was saved."));
-      }
-    } else {
-      request->send(400, "text/plain", F("No valid parameters detected!"));
-    }
-  });
+  server_.on(
+      "/file", HTTP_POST,
+      [](AsyncWebServerRequest *request) {
+        auto *context = static_cast<UploadContext *>(request->_tempObject);
+        if (!context) {
+          request->send(400, "text/plain", F("No file uploaded."));
+          return;
+        }
+
+        if (context->error) {
+          request->send(500, "text/plain", F("Failed to save file."));
+        } else {
+          request->send(200, "text/plain", F("File was saved."));
+        }
+
+        if (request->_tempFile) {
+          request->_tempFile.close();
+          request->_tempFile = File();
+        }
+
+        delete context;
+        request->_tempObject = nullptr;
+      },
+      [this](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data,
+             size_t len, bool final) {
+        handleFileUpload(request, filename, index, data, len, final);
+      });
 
   server_.on("/file", HTTP_DELETE, [this](AsyncWebServerRequest *request) {
     if (request->hasParam("file")) {
@@ -168,4 +216,71 @@ void WebServerManager::registerRoutes() {
   server_.onNotFound([](AsyncWebServerRequest *request) {
     request->send(404, "text/plain", "Not found");
   });
+}
+
+void WebServerManager::handleFileUpload(AsyncWebServerRequest *request, const String &filename,
+                                        size_t index, uint8_t *data, size_t len, bool final) {
+  auto *context = static_cast<UploadContext *>(request->_tempObject);
+
+  if (index == 0) {
+    String desiredName = filename;
+    if (request->hasParam("name", true)) {
+      desiredName = request->getParam("name", true)->value();
+    }
+
+    String sanitized = sanitizeFileName(desiredName);
+    if (!context) {
+      context = new UploadContext();
+      request->_tempObject = context;
+    }
+
+    context->finalPath = "/anims/" + sanitized;
+    context->tempPath = context->finalPath + F(".tmp");
+
+    if (request->_tempFile) {
+      request->_tempFile.close();
+    }
+
+    SPIFFS.remove(context->tempPath);
+
+    request->_tempFile = SPIFFS.open(context->tempPath, FILE_WRITE);
+    if (!request->_tempFile) {
+      context->error = true;
+      Serial.println(F("[E] Failed to open temporary file for upload."));
+      return;
+    }
+  }
+
+  if (!context) {
+    Serial.println(F("[E] Upload context missing."));
+    return;
+  }
+
+  if (len && request->_tempFile && !context->error) {
+    size_t written = request->_tempFile.write(data, len);
+    if (written != len) {
+      context->error = true;
+      Serial.println(F("[E] Failed to write uploaded data."));
+    }
+  }
+
+  if (final) {
+    if (request->_tempFile) {
+      request->_tempFile.close();
+    }
+
+    if (context->error) {
+      SPIFFS.remove(context->tempPath);
+      return;
+    }
+
+    SPIFFS.remove(context->finalPath);
+    if (!SPIFFS.rename(context->tempPath, context->finalPath)) {
+      context->error = true;
+      SPIFFS.remove(context->tempPath);
+      Serial.println(F("[E] Failed to finalize uploaded file."));
+    } else {
+      Serial.println(F("[I] File uploaded!"));
+    }
+  }
 }

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -49,7 +49,8 @@ String sanitizeFileName(String name) {
 } // namespace
 
 WebServerManager::WebServerManager(EmotionState &emotionState, FanController &fanController,
-                                   EarController &earController, TiltController &tiltController)
+                                   EarController &earController, TiltController &tiltController,
+                                   AnimationManager &animationManager)
     : server_(80),
       emotionState_(emotionState),
       fanController_(fanController),

--- a/src/WebServerManager.hpp
+++ b/src/WebServerManager.hpp
@@ -23,6 +23,8 @@ public:
 
 private:
   void registerRoutes();
+  void handleFileUpload(AsyncWebServerRequest *request, const String &filename,
+                        size_t index, uint8_t *data, size_t len, bool final);
 
   AsyncWebServer server_;
   EmotionState &emotionState_;


### PR DESCRIPTION
## Summary
- stream uploaded animation chunks into a temporary file before moving them into /anims
- add a dedicated upload handler for the web server and sanitize requested filenames
- update the web UI to submit uploads via multipart FormData so binary data is preserved

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68facc29fea4832db7f07a300edbec24