### PR TITLE
Fix multipart upload handling for animations

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -552,21 +552,25 @@
           setText(uploadStatus, "Please choose a file.");
           return;
         }
+
         var file = fileInput.files[0];
         var name = fileNameInput.value.trim() || file.name;
         if (!name) {
           setText(uploadStatus, "File name is required.");
           return;
         }
-        file.text().then(function (content) {
-          var body = new URLSearchParams({ file: name, content: content });
-          return fetchText("/file", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded" },
-            body: body
-          });
+
+        var formData = new FormData();
+        formData.append("file", file, name);
+
+        setText(uploadStatus, "Uploading...");
+
+        fetchText("/file", {
+          method: "POST",
+          body: formData
         }).then(function (text) {
           setText(uploadStatus, text);
+          uploadForm.reset();
           refreshFiles();
         }).catch(function (error) {
           setText(uploadStatus, "Error: " + error.message);

--- a/src/WebServerManager.hpp
+++ b/src/WebServerManager.hpp
@@ -23,6 +23,8 @@ public:
 
 private:
   void registerRoutes();
+  void handleFileUpload(AsyncWebServerRequest *request, const String &filename,
+                        size_t index, uint8_t *data, size_t len, bool final);
 
   AsyncWebServer server_;
   EmotionState &emotionState_;


### PR DESCRIPTION
## Summary
- ignore non-file multipart form parts and guard duplicate callbacks in the upload handler so binary chunks are processed reliably
- rely on the provided filename (with optional `name` override) when sanitizing destinations and send an explicit 400 only when no file data arrives
- remove the unused form-data field from the web UI and allocate a concrete ArduinoJson document size before serializing the file list

## Testing
- not run (hardware-specific build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68facc29fea4832db7f07a300edbec24