### PR TITLE
Fix BLE emotion command paths

### DIFF
--- a/src/BLEController.cpp
+++ b/src/BLEController.cpp
@@ -53,7 +53,7 @@ void BLEController::CharacteristicCallbacks::onWrite(NimBLECharacteristic *pChar
     if (characteristicValue.toInt() > 0 && characteristicValue.toInt() <= emotionCount)
     { // legacy remote reasons
         auto newEmotion = emotions[characteristicValue.toInt() - 1];
-        emotionState_.setCurrentEmotion(newEmotion.name);
+        emotionState_.setCurrentEmotion(newEmotion.path);
         return;
     }
     
@@ -62,9 +62,9 @@ void BLEController::CharacteristicCallbacks::onWrite(NimBLECharacteristic *pChar
         auto emotion = emotions[i];
         if (characteristicValue == emotion.name)
         {
-            emotionState_.setCurrentEmotion(emotion.name);
+            emotionState_.setCurrentEmotion(emotion.path);
         }
-    } 
+    }
 }
 
 class ServerCallbacks : public NimBLEServerCallbacks


### PR DESCRIPTION
## Summary
- update the BLE handler to set the current emotion using the animation's full file path so the GIF can be loaded correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691afc72ff68832d85c7c9d798ee3559)