### PR TITLE
Refactor ear brightness controls into serializable object

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -299,6 +299,17 @@
     <h1>Protogen Web Control</h1>
 
     <section>
+      <h2>Emotion</h2>
+      <div class="display-row">
+        <div class="value-display">Current: <span id="emotionCurrent" class="value">--</span></div>
+        <button id="emotionRefresh" class="icon-button" type="button" aria-label="Refresh emotion"
+          title="Refresh">↻</button>
+      </div>
+      <div id="emotionButtons" class="row emotion-buttons" aria-live="polite"></div>
+      <div id="emotionStatus" class="status"></div>
+    </section>
+
+    <section>
       <h2>Animation Files</h2>
       <form id="uploadForm">
         <div class="display-row">
@@ -313,24 +324,13 @@
           </label>
           <input id="fileName" type="text" placeholder="example.gif" required>
         </div>
-      <div class="row">
-        <button type="submit">Upload</button>
-      </div>
+        <div class="row">
+          <button type="submit">Upload</button>
+        </div>
       </form>
       <div id="uploadStatus" class="status"></div>
       <div id="filesStatus" class="status"></div>
       <div id="fileList" class="file-list" aria-live="polite"></div>
-    </section>
-
-    <section>
-      <h2>Emotion</h2>
-      <div class="display-row">
-        <div class="value-display">Current: <span id="emotionCurrent" class="value">--</span></div>
-        <button id="emotionRefresh" class="icon-button" type="button" aria-label="Refresh emotion"
-          title="Refresh">↻</button>
-      </div>
-      <div id="emotionButtons" class="row emotion-buttons" aria-live="polite"></div>
-      <div id="emotionStatus" class="status"></div>
     </section>
 
     <section>

--- a/data/index.html
+++ b/data/index.html
@@ -353,15 +353,15 @@
       <h2>Ears</h2>
       <div class="display-row">
         <div class="value-display">Color: <span id="earColorText" class="value">--</span> | Brightness: <span
-            id="earBrightnessText" class="value">--</span></div>
+            id="earBrightnessText" class="value">--%</span></div>
         <button id="earRefresh" class="icon-button" type="button" aria-label="Refresh ears" title="Refresh">↻</button>
       </div>
       <div class="row">
         <label for="earColor">Color</label>
         <input id="earColor" type="color" value="#ffffff">
         <label for="earBrightness">Brightness</label>
-        <input id="earBrightness" type="range" min="0" max="255" value="128">
-        <span id="earBrightnessValue" class="value">128</span>
+        <input id="earBrightness" type="range" min="0" max="100" value="50">
+        <span id="earBrightnessValue" class="value">50%</span>
         <button id="earApply" type="button">Apply</button>
       </div>
       <div id="earStatus" class="status"></div>
@@ -431,7 +431,7 @@
       });
 
       earBrightness.addEventListener("input", function () {
-        setText(earBrightnessValue, earBrightness.value);
+        setText(earBrightnessValue, earBrightness.value + "%");
       });
 
       function fetchText(url, options) {
@@ -557,18 +557,22 @@
       }
 
       function refreshEars() {
-        fetchText("/ears").then(function (response) {
-          var parts = response.trim().split(/\s+/);
-          var color = (parts[0] || "#ffffff").toLowerCase();
-          var brightness = parseInt(parts[1] || "0", 10);
+        fetchJson("/ears").then(function (data) {
+          var payload = (data && typeof data === "object" && !Array.isArray(data)) ? data : {};
+          var color = typeof payload.color === "string" ? payload.color.toLowerCase() : "#ffffff";
+          var brightnessPercent = Number(payload.brightnessPercent);
           setText(earColorText, color);
-          setText(earBrightnessText, isFinite(brightness) ? brightness : "--");
           if (/^#[0-9a-f]{6}$/i.test(color)) {
             earColor.value = color;
           }
-          if (isFinite(brightness)) {
-            earBrightness.value = brightness;
-            setText(earBrightnessValue, brightness);
+          if (isFinite(brightnessPercent)) {
+            var rounded = Math.round(brightnessPercent);
+            setText(earBrightnessText, rounded + "%");
+            earBrightness.value = rounded;
+            setText(earBrightnessValue, rounded + "%");
+          } else {
+            setText(earBrightnessText, "--%");
+            setText(earBrightnessValue, "--%");
           }
           setText(earStatus, "");
         }).catch(function (error) {
@@ -579,7 +583,7 @@
       function applyEars() {
         var body = new URLSearchParams({
           color: earColor.value,
-          brightness: earBrightness.value
+          brightnessPercent: earBrightness.value
         });
         fetchText("/ears", {
           method: "PUT",

--- a/src/EarController.cpp
+++ b/src/EarController.cpp
@@ -1,61 +1,186 @@
 #include "EarController.hpp"
 
+#include <math.h>
+
+namespace {
+constexpr float kMaxBrightnessPercent = 100.0f;
+constexpr float kMinBrightnessPercent = 0.0f;
+constexpr float kPercentToByte = 255.0f / 100.0f;
+}
+
+void Ear::Color::set(uint8_t r, uint8_t g, uint8_t b) {
+  red = r;
+  green = g;
+  blue = b;
+}
+
+String Ear::Color::toHexString() const {
+  char buffer[8];
+  snprintf(buffer, sizeof(buffer), "#%02x%02x%02x", red, green, blue);
+  return String(buffer);
+}
+
+bool Ear::Color::setFromHex(const String &hex) {
+  if (hex.length() != 7 || hex.charAt(0) != '#') {
+    return false;
+  }
+
+  auto parseComponent = [&hex](uint8_t start) -> int {
+    String component = hex.substring(start, start + 2);
+    long value = strtol(component.c_str(), nullptr, 16);
+    if (value < 0 || value > 255) {
+      return -1;
+    }
+    return static_cast<int>(value);
+  };
+
+  const int r = parseComponent(1);
+  const int g = parseComponent(3);
+  const int b = parseComponent(5);
+  if (r < 0 || g < 0 || b < 0) {
+    return false;
+  }
+
+  set(static_cast<uint8_t>(r), static_cast<uint8_t>(g), static_cast<uint8_t>(b));
+  return true;
+}
+
+Ear::Brightness::Brightness(uint8_t value) : value_(value) {}
+
+void Ear::Brightness::setValue(uint8_t value) {
+  value_ = value;
+}
+
+uint8_t Ear::Brightness::getValue() const {
+  return value_;
+}
+
+void Ear::Brightness::setPercent(float percent) {
+  float clamped = percent;
+  if (clamped < kMinBrightnessPercent) {
+    clamped = kMinBrightnessPercent;
+  } else if (clamped > kMaxBrightnessPercent) {
+    clamped = kMaxBrightnessPercent;
+  }
+  value_ = static_cast<uint8_t>(roundf(clamped * kPercentToByte));
+}
+
+float Ear::Brightness::getPercent() const {
+  return (static_cast<float>(value_) / 255.0f) * 100.0f;
+}
+
+Ear::Ear() : color_(), brightness_() {}
+
+void Ear::setColor(uint8_t red, uint8_t green, uint8_t blue) {
+  color_.set(red, green, blue);
+}
+
+bool Ear::setColorFromHex(const String &hex) {
+  return color_.setFromHex(hex);
+}
+
+const Ear::Color &Ear::getColor() const {
+  return color_;
+}
+
+String Ear::getColorHexString() const {
+  return color_.toHexString();
+}
+
+void Ear::setBrightness(uint8_t brightness) {
+  brightness_.setValue(brightness);
+}
+
+void Ear::setBrightnessPercent(float percent) {
+  brightness_.setPercent(percent);
+}
+
+bool Ear::setBrightnessPercentChecked(float percent) {
+  if (percent < kMinBrightnessPercent || percent > kMaxBrightnessPercent) {
+    return false;
+  }
+  setBrightnessPercent(percent);
+  return true;
+}
+
+uint8_t Ear::getBrightness() const {
+  return brightness_.getValue();
+}
+
+float Ear::getBrightnessPercent() const {
+  return brightness_.getPercent();
+}
+
+void Ear::serialize(JsonVariant json) const {
+  if (json.isNull()) {
+    return;
+  }
+
+  json["color"] = getColorHexString();
+  json["brightness"] = getBrightness();
+  json["brightnessPercent"] = getBrightnessPercent();
+}
+
 EarController::EarController(uint16_t ledCount, uint8_t dataPin)
     : ledCount_(ledCount),
       earLeds_(ledCount, dataPin, NEO_GRB + NEO_KHZ800),
-      brightness_(80),
-      red_(255),
-      green_(255),
-      blue_(255) {}
+      ear_() {}
 
 bool EarController::begin() {
   earLeds_.begin();
-  earLeds_.setBrightness(brightness_);
+  earLeds_.setBrightness(ear_.getBrightness());
   return true;
 }
 
 void EarController::setBrightness(uint8_t brightness) {
-  brightness_ = brightness;
+  ear_.setBrightness(brightness);
+}
+
+void EarController::setBrightnessPercent(float percent) {
+  ear_.setBrightnessPercent(percent);
 }
 
 uint8_t EarController::getBrightness() const {
-  return brightness_;
+  return ear_.getBrightness();
 }
 
 void EarController::setColor(uint8_t red, uint8_t green, uint8_t blue) {
-  red_ = red;
-  green_ = green;
-  blue_ = blue;
+  ear_.setColor(red, green, blue);
 }
 
 uint8_t EarController::getRed() const {
-  return red_;
+  return ear_.getColor().red;
 }
 
 uint8_t EarController::getGreen() const {
-  return green_;
+  return ear_.getColor().green;
 }
 
 uint8_t EarController::getBlue() const {
-  return blue_;
+  return ear_.getColor().blue;
 }
 
 String EarController::getColorHexString() const {
-  String result = "#";
-  result += String(red_, 16);
-  result += String(green_, 16);
-  result += String(blue_, 16);
-  return result;
+  return ear_.getColorHexString();
 }
 
-float EarController::getBrightnessPercent() const{
-  return (static_cast<float>(getBrightness()) / 255.0f) * 100.0f;
+float EarController::getBrightnessPercent() const {
+  return ear_.getBrightnessPercent();
+}
+
+Ear &EarController::getEar() {
+  return ear_;
+}
+
+const Ear &EarController::getEar() const {
+  return ear_;
 }
 
 void EarController::update() {
-  earLeds_.setBrightness(brightness_);
+  const auto &color = ear_.getColor();
+  earLeds_.setBrightness(ear_.getBrightness());
   for (uint16_t index = 0; index < ledCount_; ++index) {
-    earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(red_, green_, blue_));
+    earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(color.red, color.green, color.blue));
   }
   earLeds_.show();
 }

--- a/src/EarController.cpp
+++ b/src/EarController.cpp
@@ -148,18 +148,6 @@ void EarController::setColor(uint8_t red, uint8_t green, uint8_t blue) {
   ear_.setColor(red, green, blue);
 }
 
-uint8_t EarController::getRed() const {
-  return ear_.getColor().red;
-}
-
-uint8_t EarController::getGreen() const {
-  return ear_.getColor().green;
-}
-
-uint8_t EarController::getBlue() const {
-  return ear_.getColor().blue;
-}
-
 String EarController::getColorHexString() const {
   return ear_.getColorHexString();
 }
@@ -169,10 +157,6 @@ float EarController::getBrightnessPercent() const {
 }
 
 Ear &EarController::getEar() {
-  return ear_;
-}
-
-const Ear &EarController::getEar() const {
   return ear_;
 }
 

--- a/src/EarController.hpp
+++ b/src/EarController.hpp
@@ -60,15 +60,11 @@ public:
   uint8_t getBrightness() const;
 
   void setColor(uint8_t red, uint8_t green, uint8_t blue);
-  uint8_t getRed() const;
-  uint8_t getGreen() const;
-  uint8_t getBlue() const;
 
   String getColorHexString() const;
   float getBrightnessPercent() const;
 
   Ear &getEar();
-  const Ear &getEar() const;
 
   void update();
 

--- a/src/EarController.hpp
+++ b/src/EarController.hpp
@@ -3,6 +3,52 @@
 
 #include <Adafruit_NeoPixel.h>
 #include <Arduino.h>
+#include <ArduinoJson.h>
+
+class Ear {
+public:
+  struct Color {
+    uint8_t red = 255;
+    uint8_t green = 255;
+    uint8_t blue = 255;
+
+    void set(uint8_t r, uint8_t g, uint8_t b);
+    String toHexString() const;
+    bool setFromHex(const String &hex);
+  };
+
+  class Brightness {
+  public:
+    explicit Brightness(uint8_t value = 80);
+
+    void setValue(uint8_t value);
+    uint8_t getValue() const;
+    void setPercent(float percent);
+    float getPercent() const;
+
+  private:
+    uint8_t value_;
+  };
+
+  Ear();
+
+  void setColor(uint8_t red, uint8_t green, uint8_t blue);
+  bool setColorFromHex(const String &hex);
+  const Color &getColor() const;
+  String getColorHexString() const;
+
+  void setBrightness(uint8_t brightness);
+  void setBrightnessPercent(float percent);
+  bool setBrightnessPercentChecked(float percent);
+  uint8_t getBrightness() const;
+  float getBrightnessPercent() const;
+
+  void serialize(JsonVariant json) const;
+
+private:
+  Color color_;
+  Brightness brightness_;
+};
 
 class EarController {
 public:
@@ -10,6 +56,7 @@ public:
 
   bool begin();
   void setBrightness(uint8_t brightness);
+  void setBrightnessPercent(float percent);
   uint8_t getBrightness() const;
 
   void setColor(uint8_t red, uint8_t green, uint8_t blue);
@@ -20,15 +67,15 @@ public:
   String getColorHexString() const;
   float getBrightnessPercent() const;
 
+  Ear &getEar();
+  const Ear &getEar() const;
+
   void update();
 
 private:
   uint16_t ledCount_;
   Adafruit_NeoPixel earLeds_;
-  uint8_t brightness_;
-  uint8_t red_;
-  uint8_t green_;
-  uint8_t blue_;
+  Ear ear_;
 };
 
 #endif // EAR_CONTROLLER_HPP

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -137,28 +137,51 @@ void WebServerManager::registerRoutes() {
   });
 
   server_.on("/ears", HTTP_GET, [this](AsyncWebServerRequest *request) {
-    request->send(200, "text/plain", earController_.getColorHexString()+ F(" ") + earController_.getBrightness());
+    JsonDocument doc;
+    JsonObject obj = doc.to<JsonObject>();
+    earController_.getEar().serialize(obj);
+
+    String json;
+    serializeJson(doc, json);
+    request->send(200, "application/json", json);
   });
 
   server_.on("/ears", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+    bool updated = false;
+
+    Ear &ear = earController_.getEar();
+
     if (request->hasParam("color", true)) {
       String color = request->getParam("color", true)->value();
-      int r = 0, g = 0, b = 0;
-      int itemsFound = sscanf(color.c_str(), "#%02x%02x%02x", &r, &g, &b);
-      if (itemsFound != 3) {
+      if (!ear.setColorFromHex(color)) {
         request->send(400, "text/plain", F("Could not set color use #FFFFFF format."));
         return;
       }
-      earController_.setColor(static_cast<uint8_t>(r), static_cast<uint8_t>(g), static_cast<uint8_t>(b));
+      updated = true;
     }
-    if (request->hasParam("brightness", true)) {
+
+    if (request->hasParam("brightnessPercent", true)) {
+      const float percent = request->getParam("brightnessPercent", true)->value().toFloat();
+      if (!ear.setBrightnessPercentChecked(percent)) {
+        request->send(400, "text/plain", F("Could not set brightness use 0-100 percent."));
+        return;
+      }
+      updated = true;
+    } else if (request->hasParam("brightness", true)) {
       int brightness = request->getParam("brightness", true)->value().toInt();
       if (brightness >= 256 || brightness < 0) {
         request->send(400, "text/plain", F("Could not set brightness use 0-255 value."));
         return;
       }
-      earController_.setBrightness(static_cast<uint8_t>(brightness));
+      ear.setBrightness(static_cast<uint8_t>(brightness));
+      updated = true;
     }
+
+    if (!updated) {
+      request->send(400, "text/plain", F("No valid parameters detected!"));
+      return;
+    }
+
     request->send(200, "text/plain", F("Color/brightness set."));
   });
 


### PR DESCRIPTION
## Summary
- introduce a dedicated `Ear` object that encapsulates RGB parsing/formatting, brightness percentage handling, and JSON serialization for the API
- update `EarController` to own the new ear object so all color/brightness logic funnels through it
- refactor the `/ears` endpoints to rely on the shared serialization/parsing helpers instead of duplicating the logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691afe870bec832dbd518f0e5438721f)