### PR TITLE
Fix GIF playback loop

### DIFF
--- a/src/AnimationManager.cpp
+++ b/src/AnimationManager.cpp
@@ -68,11 +68,24 @@ void AnimationManager::playEmotion(const String &emotionPath)
     return;
   }
 
-  if (gif_.open(emotionPath.c_str(), fileOpenWrapper, fileCloseWrapper, fileReadWrapper, fileSeekWrapper, GIFDrawWrapper))
+  if (!SPIFFS.exists(emotionPath))
   {
-    gif_.playFrame(true, nullptr);
-    gif_.close();
+    Serial.printf("[E] Emotion file missing: %s\n", emotionPath.c_str());
+    return;
   }
+
+  if (!gif_.open(emotionPath.c_str(), fileOpenWrapper, fileCloseWrapper, fileReadWrapper, fileSeekWrapper, GIFDrawWrapper))
+  {
+    Serial.printf("[E] Failed to open GIF: %s\n", emotionPath.c_str());
+    return;
+  }
+
+  while (gif_.playFrame(true, nullptr))
+  {
+    delay(0); // Allow background tasks while frames are rendered
+  }
+
+  gif_.close();
 }
 
 std::vector<AnimationInfo> AnimationManager::getEmotions()


### PR DESCRIPTION
## Summary
- ensure the animation manager validates GIF availability before attempting to render it
- play the entire GIF by iterating through frames instead of drawing only the first one, and keep the system responsive while frames render

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c7530537c832d9f64c344e1bc543f)