### PR TITLE
Add emotion CRUD with solid/gradient ear color support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,6 @@
 {
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
     "recommendations": [
         "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"

--- a/data/index.html
+++ b/data/index.html
@@ -403,7 +403,7 @@
       var emotionCurrent = $("emotionCurrent");
       var emotionStatus = $("emotionStatus");
       var emotionButtons = $("emotionButtons");
-      var currentEmotionName = "";
+      var currentEmotionPath = "";
       var fanDuty = $("fanDuty");
       var fanPercent = $("fanPercent");
       var fanSlider = $("fanSlider");
@@ -469,15 +469,17 @@
 
       function refreshEmotion(options) {
         var preserveStatus = options && options.preserveStatus;
-        return fetchText("/emotion").then(function (text) {
-          var value = (text || "").trim();
-          currentEmotionName = value;
-          setText(emotionCurrent, value || "(empty)");
-          highlightEmotion(currentEmotionName);
+        return fetchJson("/emotion").then(function (data) {
+          var payload = (data && typeof data === "object") ? data : {};
+          var name = (payload.name || "").trim();
+          var path = (payload.path || "").trim();
+          currentEmotionPath = path;
+          setText(emotionCurrent, name || path || "(empty)");
+          highlightEmotion(currentEmotionPath);
           if (!preserveStatus) {
             setText(emotionStatus, "");
           }
-          return value;
+          return payload;
         }).catch(function (error) {
           if (!preserveStatus) {
             setText(emotionStatus, "Error: " + error.message);
@@ -507,7 +509,7 @@
           fragment.appendChild(button);
         });
         emotionButtons.appendChild(fragment);
-        highlightEmotion(currentEmotionName);
+        highlightEmotion(currentEmotionPath);
       }
 
       function setEmotion(name) {
@@ -727,9 +729,9 @@
         if (!name) { return; }
         setText(emotionStatus, "Updating emotion...");
         setEmotion(name).then(function (text) {
-          currentEmotionName = name;
+          currentEmotionPath = name;
           setText(emotionCurrent, name);
-          highlightEmotion(currentEmotionName);
+          highlightEmotion(currentEmotionPath);
           setText(emotionStatus, text);
         }).catch(function (error) {
           setText(emotionStatus, "Error: " + error.message);

--- a/src/AnimationManager.cpp
+++ b/src/AnimationManager.cpp
@@ -95,9 +95,9 @@ void AnimationManager::playEmotion(const String &emotionPath)
   }
 }
 
-std::vector<AnimationInfo> AnimationManager::getEmotions()
+std::vector<AnimationFile> AnimationManager::getEmotions()
 {
-  std::vector<AnimationInfo> animations;
+  std::vector<AnimationFile> animations;
 
   File animationsDir = SPIFFS.open("/anims");
   if (!animationsDir || !animationsDir.isDirectory())
@@ -109,7 +109,7 @@ std::vector<AnimationInfo> AnimationManager::getEmotions()
   File file = animationsDir.openNextFile();
   while (file)
   {
-    AnimationInfo info;
+    AnimationFile info;
     info.path = file.path();
     info.name = FileHelper::GetNameOnly(info.path);
 

--- a/src/AnimationManager.hpp
+++ b/src/AnimationManager.hpp
@@ -8,11 +8,7 @@
 #include <Arduino.h>
 
 #include "float_helper.hpp"
-
-struct AnimationInfo {
-    String name; 
-    String path;
-};
+#include "Model/AnimationFile.hpp"
 
 class AnimationManager {
 public:
@@ -21,7 +17,7 @@ public:
 
   bool begin();
   void playEmotion(const String &emotionPath);
-  std::vector<AnimationInfo> getEmotions();
+  std::vector<AnimationFile> getEmotions();
   void printEmotions();
 
 private:

--- a/src/EarController.cpp
+++ b/src/EarController.cpp
@@ -25,9 +25,14 @@ uint8_t EarController::getBrightness() const {
   return ear_.getBrightness();
 }
 
-void EarController::setColor(uint8_t red, uint8_t green, uint8_t blue) {
-  ear_.setColor(red, green, blue);
+void EarController::setColor(Color color) {
+  ear_.setColor(color);
 }
+
+void EarController::setGradient(Gradient gradient) {
+  ear_.setGradient(gradient);
+}
+
 
 String EarController::getColorHexString() const {
   return ear_.getColorHexString();

--- a/src/EarController.cpp
+++ b/src/EarController.cpp
@@ -6,7 +6,28 @@ namespace {
 constexpr float kMaxBrightnessPercent = 100.0f;
 constexpr float kMinBrightnessPercent = 0.0f;
 constexpr float kPercentToByte = 255.0f / 100.0f;
+
+float clampUnit(float value)
+{
+  if (value < 0.0f)
+  {
+    return 0.0f;
+  }
+  if (value > 1.0f)
+  {
+    return 1.0f;
+  }
+  return value;
 }
+
+uint8_t interpolateComponent(uint8_t from, uint8_t to, float factor)
+{
+  const float start = static_cast<float>(from);
+  const float end = static_cast<float>(to);
+  const float value = start + ((end - start) * clampUnit(factor));
+  return static_cast<uint8_t>(roundf(value));
+}
+} // namespace
 
 void Ear::Color::set(uint8_t r, uint8_t g, uint8_t b) {
   red = r;
@@ -69,14 +90,19 @@ float Ear::Brightness::getPercent() const {
   return (static_cast<float>(value_) / 255.0f) * 100.0f;
 }
 
-Ear::Ear() : color_(), brightness_() {}
+Ear::Ear() : color_(), gradient_(), colorMode_(ColorMode::Solid), brightness_() {}
 
 void Ear::setColor(uint8_t red, uint8_t green, uint8_t blue) {
   color_.set(red, green, blue);
+  colorMode_ = ColorMode::Solid;
 }
 
 bool Ear::setColorFromHex(const String &hex) {
-  return color_.setFromHex(hex);
+  if (!color_.setFromHex(hex)) {
+    return false;
+  }
+  colorMode_ = ColorMode::Solid;
+  return true;
 }
 
 const Ear::Color &Ear::getColor() const {
@@ -85,6 +111,45 @@ const Ear::Color &Ear::getColor() const {
 
 String Ear::getColorHexString() const {
   return color_.toHexString();
+}
+
+bool Ear::setGradientFromHex(const String &fromHex, const String &toHex,
+                             float directionX, float directionY,
+                             float midpoint)
+{
+  Gradient gradient;
+  if (!gradient.from.setFromHex(fromHex) || !gradient.to.setFromHex(toHex))
+  {
+    return false;
+  }
+  gradient.directionX = directionX;
+  gradient.directionY = directionY;
+  gradient.midpoint = clampUnit(midpoint);
+
+  setGradient(gradient);
+  return true;
+}
+
+void Ear::setGradient(const Gradient &gradient)
+{
+  gradient_ = gradient;
+  gradient_.midpoint = clampUnit(gradient_.midpoint);
+  colorMode_ = ColorMode::Gradient;
+}
+
+const Ear::Gradient &Ear::getGradient() const
+{
+  return gradient_;
+}
+
+void Ear::setColorMode(ColorMode mode)
+{
+  colorMode_ = mode;
+}
+
+Ear::ColorMode Ear::getColorMode() const
+{
+  return colorMode_;
 }
 
 void Ear::setBrightness(uint8_t brightness) {
@@ -116,9 +181,17 @@ void Ear::serialize(JsonVariant json) const {
     return;
   }
 
+  json["mode"] = colorMode_ == ColorMode::Gradient ? "gradient" : "solid";
   json["color"] = getColorHexString();
   json["brightness"] = getBrightness();
   json["brightnessPercent"] = getBrightnessPercent();
+
+  JsonObject gradientJson = json["gradient"].to<JsonObject>();
+  gradientJson["from"] = gradient_.from.toHexString();
+  gradientJson["to"] = gradient_.to.toHexString();
+  gradientJson["directionX"] = gradient_.directionX;
+  gradientJson["directionY"] = gradient_.directionY;
+  gradientJson["midpoint"] = gradient_.midpoint;
 }
 
 EarController::EarController(uint16_t ledCount, uint8_t dataPin)
@@ -161,10 +234,49 @@ Ear &EarController::getEar() {
 }
 
 void EarController::update() {
-  const auto &color = ear_.getColor();
   earLeds_.setBrightness(ear_.getBrightness());
-  for (uint16_t index = 0; index < ledCount_; ++index) {
-    earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(color.red, color.green, color.blue));
+
+  if (ear_.getColorMode() == Ear::ColorMode::Gradient)
+  {
+    const Ear::Gradient &gradient = ear_.getGradient();
+    for (uint16_t index = 0; index < ledCount_; ++index)
+    {
+      float position = ledCount_ > 1
+                         ? static_cast<float>(index) / static_cast<float>(ledCount_ - 1)
+                         : 0.0f;
+
+      const float directionInfluence = (gradient.directionX + gradient.directionY) * 0.5f;
+      position = clampUnit(position + (directionInfluence * 0.25f));
+
+      float blend = 0.0f;
+      if (gradient.midpoint <= 0.0f)
+      {
+        blend = 1.0f;
+      }
+      else if (gradient.midpoint >= 1.0f)
+      {
+        blend = 0.0f;
+      }
+      else
+      {
+        blend = position / gradient.midpoint;
+      }
+      blend = clampUnit(blend);
+
+      const uint8_t red = interpolateComponent(gradient.from.red, gradient.to.red, blend);
+      const uint8_t green = interpolateComponent(gradient.from.green, gradient.to.green, blend);
+      const uint8_t blue = interpolateComponent(gradient.from.blue, gradient.to.blue, blend);
+      earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(red, green, blue));
+    }
   }
+  else
+  {
+    const auto &color = ear_.getColor();
+    for (uint16_t index = 0; index < ledCount_; ++index)
+    {
+      earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(color.red, color.green, color.blue));
+    }
+  }
+
   earLeds_.show();
 }

--- a/src/EarController.cpp
+++ b/src/EarController.cpp
@@ -2,198 +2,6 @@
 
 #include <math.h>
 
-namespace {
-constexpr float kMaxBrightnessPercent = 100.0f;
-constexpr float kMinBrightnessPercent = 0.0f;
-constexpr float kPercentToByte = 255.0f / 100.0f;
-
-float clampUnit(float value)
-{
-  if (value < 0.0f)
-  {
-    return 0.0f;
-  }
-  if (value > 1.0f)
-  {
-    return 1.0f;
-  }
-  return value;
-}
-
-uint8_t interpolateComponent(uint8_t from, uint8_t to, float factor)
-{
-  const float start = static_cast<float>(from);
-  const float end = static_cast<float>(to);
-  const float value = start + ((end - start) * clampUnit(factor));
-  return static_cast<uint8_t>(roundf(value));
-}
-} // namespace
-
-void Ear::Color::set(uint8_t r, uint8_t g, uint8_t b) {
-  red = r;
-  green = g;
-  blue = b;
-}
-
-String Ear::Color::toHexString() const {
-  char buffer[8];
-  snprintf(buffer, sizeof(buffer), "#%02x%02x%02x", red, green, blue);
-  return String(buffer);
-}
-
-bool Ear::Color::setFromHex(const String &hex) {
-  if (hex.length() != 7 || hex.charAt(0) != '#') {
-    return false;
-  }
-
-  auto parseComponent = [&hex](uint8_t start) -> int {
-    String component = hex.substring(start, start + 2);
-    long value = strtol(component.c_str(), nullptr, 16);
-    if (value < 0 || value > 255) {
-      return -1;
-    }
-    return static_cast<int>(value);
-  };
-
-  const int r = parseComponent(1);
-  const int g = parseComponent(3);
-  const int b = parseComponent(5);
-  if (r < 0 || g < 0 || b < 0) {
-    return false;
-  }
-
-  set(static_cast<uint8_t>(r), static_cast<uint8_t>(g), static_cast<uint8_t>(b));
-  return true;
-}
-
-Ear::Brightness::Brightness(uint8_t value) : value_(value) {}
-
-void Ear::Brightness::setValue(uint8_t value) {
-  value_ = value;
-}
-
-uint8_t Ear::Brightness::getValue() const {
-  return value_;
-}
-
-void Ear::Brightness::setPercent(float percent) {
-  float clamped = percent;
-  if (clamped < kMinBrightnessPercent) {
-    clamped = kMinBrightnessPercent;
-  } else if (clamped > kMaxBrightnessPercent) {
-    clamped = kMaxBrightnessPercent;
-  }
-  value_ = static_cast<uint8_t>(roundf(clamped * kPercentToByte));
-}
-
-float Ear::Brightness::getPercent() const {
-  return (static_cast<float>(value_) / 255.0f) * 100.0f;
-}
-
-Ear::Ear() : color_(), gradient_(), colorMode_(ColorMode::Solid), brightness_() {}
-
-void Ear::setColor(uint8_t red, uint8_t green, uint8_t blue) {
-  color_.set(red, green, blue);
-  colorMode_ = ColorMode::Solid;
-}
-
-bool Ear::setColorFromHex(const String &hex) {
-  if (!color_.setFromHex(hex)) {
-    return false;
-  }
-  colorMode_ = ColorMode::Solid;
-  return true;
-}
-
-const Ear::Color &Ear::getColor() const {
-  return color_;
-}
-
-String Ear::getColorHexString() const {
-  return color_.toHexString();
-}
-
-bool Ear::setGradientFromHex(const String &fromHex, const String &toHex,
-                             float directionX, float directionY,
-                             float midpoint)
-{
-  Gradient gradient;
-  if (!gradient.from.setFromHex(fromHex) || !gradient.to.setFromHex(toHex))
-  {
-    return false;
-  }
-  gradient.directionX = directionX;
-  gradient.directionY = directionY;
-  gradient.midpoint = clampUnit(midpoint);
-
-  setGradient(gradient);
-  return true;
-}
-
-void Ear::setGradient(const Gradient &gradient)
-{
-  gradient_ = gradient;
-  gradient_.midpoint = clampUnit(gradient_.midpoint);
-  colorMode_ = ColorMode::Gradient;
-}
-
-const Ear::Gradient &Ear::getGradient() const
-{
-  return gradient_;
-}
-
-void Ear::setColorMode(ColorMode mode)
-{
-  colorMode_ = mode;
-}
-
-Ear::ColorMode Ear::getColorMode() const
-{
-  return colorMode_;
-}
-
-void Ear::setBrightness(uint8_t brightness) {
-  brightness_.setValue(brightness);
-}
-
-void Ear::setBrightnessPercent(float percent) {
-  brightness_.setPercent(percent);
-}
-
-bool Ear::setBrightnessPercentChecked(float percent) {
-  if (percent < kMinBrightnessPercent || percent > kMaxBrightnessPercent) {
-    return false;
-  }
-  setBrightnessPercent(percent);
-  return true;
-}
-
-uint8_t Ear::getBrightness() const {
-  return brightness_.getValue();
-}
-
-float Ear::getBrightnessPercent() const {
-  return brightness_.getPercent();
-}
-
-void Ear::serialize(JsonVariant json) const {
-  if (json.isNull()) {
-    return;
-  }
-
-  json["mode"] = colorMode_ == ColorMode::Gradient ? "gradient" : "solid";
-  json["color"] = getColorHexString();
-  json["brightness"] = getBrightness();
-  json["brightnessPercent"] = getBrightnessPercent();
-
-  JsonObject gradientJson = json["gradient"].to<JsonObject>();
-  gradientJson["from"] = gradient_.from.toHexString();
-  gradientJson["to"] = gradient_.to.toHexString();
-  gradientJson["directionX"] = gradient_.directionX;
-  gradientJson["directionY"] = gradient_.directionY;
-  gradientJson["midpoint"] = gradient_.midpoint;
-}
-
 EarController::EarController(uint16_t ledCount, uint8_t dataPin)
     : ledCount_(ledCount),
       earLeds_(ledCount, dataPin, NEO_GRB + NEO_KHZ800),
@@ -236,37 +44,13 @@ Ear &EarController::getEar() {
 void EarController::update() {
   earLeds_.setBrightness(ear_.getBrightness());
 
-  if (ear_.getColorMode() == Ear::ColorMode::Gradient)
+  if (ear_.getColorMode() == ColorMode::Gradient)
   {
-    const Ear::Gradient &gradient = ear_.getGradient();
+    const auto &gradient = ear_.getGradient();
     for (uint16_t index = 0; index < ledCount_; ++index)
     {
-      float position = ledCount_ > 1
-                         ? static_cast<float>(index) / static_cast<float>(ledCount_ - 1)
-                         : 0.0f;
-
-      const float directionInfluence = (gradient.directionX + gradient.directionY) * 0.5f;
-      position = clampUnit(position + (directionInfluence * 0.25f));
-
-      float blend = 0.0f;
-      if (gradient.midpoint <= 0.0f)
-      {
-        blend = 1.0f;
-      }
-      else if (gradient.midpoint >= 1.0f)
-      {
-        blend = 0.0f;
-      }
-      else
-      {
-        blend = position / gradient.midpoint;
-      }
-      blend = clampUnit(blend);
-
-      const uint8_t red = interpolateComponent(gradient.from.red, gradient.to.red, blend);
-      const uint8_t green = interpolateComponent(gradient.from.green, gradient.to.green, blend);
-      const uint8_t blue = interpolateComponent(gradient.from.blue, gradient.to.blue, blend);
-      earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(red, green, blue));
+      auto color = gradient.rasterizeColor(index, ledCount_);
+      earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(color.getRed(), color.getGreen(), color.getBlue()));
     }
   }
   else
@@ -274,7 +58,7 @@ void EarController::update() {
     const auto &color = ear_.getColor();
     for (uint16_t index = 0; index < ledCount_; ++index)
     {
-      earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(color.red, color.green, color.blue));
+      earLeds_.setPixelColor(index, Adafruit_NeoPixel::Color(color.getRed(), color.getGreen(), color.getBlue()));
     }
   }
 

--- a/src/EarController.hpp
+++ b/src/EarController.hpp
@@ -16,7 +16,8 @@ public:
   void setBrightnessPercent(float percent);
   uint8_t getBrightness() const;
 
-  void setColor(uint8_t red, uint8_t green, uint8_t blue);
+  void setColor(Color color);
+  void setGradient(Gradient gradient);
 
   String getColorHexString() const;
   float getBrightnessPercent() const;

--- a/src/EarController.hpp
+++ b/src/EarController.hpp
@@ -17,6 +17,19 @@ public:
     bool setFromHex(const String &hex);
   };
 
+  struct Gradient {
+    Color from;
+    Color to;
+    float directionX = 1.0f;
+    float directionY = 0.0f;
+    float midpoint = 0.5f;
+  };
+
+  enum class ColorMode {
+    Solid,
+    Gradient,
+  };
+
   class Brightness {
   public:
     explicit Brightness(uint8_t value = 80);
@@ -37,6 +50,15 @@ public:
   const Color &getColor() const;
   String getColorHexString() const;
 
+  bool setGradientFromHex(const String &fromHex, const String &toHex,
+                          float directionX, float directionY,
+                          float midpoint);
+  void setGradient(const Gradient &gradient);
+  const Gradient &getGradient() const;
+
+  void setColorMode(ColorMode mode);
+  ColorMode getColorMode() const;
+
   void setBrightness(uint8_t brightness);
   void setBrightnessPercent(float percent);
   bool setBrightnessPercentChecked(float percent);
@@ -47,6 +69,8 @@ public:
 
 private:
   Color color_;
+  Gradient gradient_;
+  ColorMode colorMode_;
   Brightness brightness_;
 };
 

--- a/src/EarController.hpp
+++ b/src/EarController.hpp
@@ -5,74 +5,7 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 
-class Ear {
-public:
-  struct Color {
-    uint8_t red = 255;
-    uint8_t green = 255;
-    uint8_t blue = 255;
-
-    void set(uint8_t r, uint8_t g, uint8_t b);
-    String toHexString() const;
-    bool setFromHex(const String &hex);
-  };
-
-  struct Gradient {
-    Color from;
-    Color to;
-    float directionX = 1.0f;
-    float directionY = 0.0f;
-    float midpoint = 0.5f;
-  };
-
-  enum class ColorMode {
-    Solid,
-    Gradient,
-  };
-
-  class Brightness {
-  public:
-    explicit Brightness(uint8_t value = 80);
-
-    void setValue(uint8_t value);
-    uint8_t getValue() const;
-    void setPercent(float percent);
-    float getPercent() const;
-
-  private:
-    uint8_t value_;
-  };
-
-  Ear();
-
-  void setColor(uint8_t red, uint8_t green, uint8_t blue);
-  bool setColorFromHex(const String &hex);
-  const Color &getColor() const;
-  String getColorHexString() const;
-
-  bool setGradientFromHex(const String &fromHex, const String &toHex,
-                          float directionX, float directionY,
-                          float midpoint);
-  void setGradient(const Gradient &gradient);
-  const Gradient &getGradient() const;
-
-  void setColorMode(ColorMode mode);
-  ColorMode getColorMode() const;
-
-  void setBrightness(uint8_t brightness);
-  void setBrightnessPercent(float percent);
-  bool setBrightnessPercentChecked(float percent);
-  uint8_t getBrightness() const;
-  float getBrightnessPercent() const;
-
-  void serialize(JsonVariant json) const;
-
-private:
-  Color color_;
-  Gradient gradient_;
-  ColorMode colorMode_;
-  Brightness brightness_;
-};
+#include "Model/Ear.hpp"
 
 class EarController {
 public:

--- a/src/EmotionState.cpp
+++ b/src/EmotionState.cpp
@@ -1,15 +1,5 @@
 #include "EmotionState.hpp"
 
-namespace {
-EmotionState::EarColor MakeSolidEarColor(const String &hex)
-{
-  EmotionState::EarColor earColor;
-  earColor.type = EmotionState::EarColor::Type::Solid;
-  earColor.solidColor = hex;
-  return earColor;
-}
-} // namespace
-
 EmotionState::EmotionState()
     : currentEmotion_("/anims/neutral.gif"),
       previousEmotion_("/anims/neutral.gif"),
@@ -17,11 +7,11 @@ EmotionState::EmotionState()
       tiltSideEmotion_("/anims/confused.gif")
 {
   seedEmotionDefinitions({
-      {"neutral", "/anims/neutral.gif", MakeSolidEarColor("#ffffff")},
-      {"happy", "/anims/happy.gif", MakeSolidEarColor("#fff36b")},
-      {"sad", "/anims/sad.gif", MakeSolidEarColor("#6bb4ff")},
-      {"evil", "/anims/evil.gif", MakeSolidEarColor("#ff6767")},
-      {"blush", "/anims/blush.gif", MakeSolidEarColor("#ff99b8")},
+      EmotionDefinition("Neutral", "/anims/neutral.gif", Color(255, 255, 255), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Happy", "/anims/happy.gif", Color(255, 255, 0), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Confused", "/anims/confused.gif", Color(255, 0, 255), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Sad", "/anims/sad.gif", Color(0, 0, 255), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Angry", "/anims/angry.gif", Color(255, 0, 0), Gradient(), ColorMode::Solid)
   });
 }
 
@@ -86,12 +76,12 @@ void EmotionState::setTiltSideEmotion(const String &emotionName)
   tiltSideEmotion_ = emotionName;
 }
 
-const std::vector<EmotionState::EmotionDefinition> &EmotionState::getEmotionDefinitions() const
+const std::vector<EmotionDefinition> &EmotionState::getEmotionDefinitions() const
 {
   return emotionDefinitions_;
 }
 
-const EmotionState::EmotionDefinition *EmotionState::getEmotionDefinitionByName(const String &name) const
+const EmotionDefinition *EmotionState::getEmotionDefinitionByName(const String &name) const
 {
   const int index = findEmotionIndexByName(name);
   if (index < 0)
@@ -101,7 +91,7 @@ const EmotionState::EmotionDefinition *EmotionState::getEmotionDefinitionByName(
   return &emotionDefinitions_[static_cast<size_t>(index)];
 }
 
-const EmotionState::EmotionDefinition *EmotionState::getEmotionDefinitionByPath(const String &path) const
+const EmotionDefinition *EmotionState::getEmotionDefinitionByPath(const String &path) const
 {
   const int index = findEmotionIndexByPath(path);
   if (index < 0)
@@ -111,7 +101,7 @@ const EmotionState::EmotionDefinition *EmotionState::getEmotionDefinitionByPath(
   return &emotionDefinitions_[static_cast<size_t>(index)];
 }
 
-const EmotionState::EmotionDefinition *EmotionState::getCurrentEmotionDefinition() const
+const EmotionDefinition *EmotionState::getCurrentEmotionDefinition() const
 {
   return getEmotionDefinitionByPath(currentEmotion_);
 }

--- a/src/EmotionState.cpp
+++ b/src/EmotionState.cpp
@@ -7,11 +7,12 @@ EmotionState::EmotionState()
       tiltSideEmotion_("/anims/confused.gif")
 {
   seedEmotionDefinitions({
-      EmotionDefinition("Neutral", "/anims/neutral.gif", Color(255, 255, 255), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Blush", "/anims/blush.gif", Color(255, 192, 203), Gradient(), ColorMode::Gradient),
+      EmotionDefinition("Cute", "/anims/cute.gif", Color(255, 192, 203), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Evil", "/anims/evil.gif", Color(0, 0, 0), Gradient(), ColorMode::Solid),
       EmotionDefinition("Happy", "/anims/happy.gif", Color(255, 255, 0), Gradient(), ColorMode::Solid),
-      EmotionDefinition("Confused", "/anims/confused.gif", Color(255, 0, 255), Gradient(), ColorMode::Solid),
+      EmotionDefinition("Neutral", "/anims/neutral.gif", Color(255, 255, 255), Gradient(), ColorMode::Solid),
       EmotionDefinition("Sad", "/anims/sad.gif", Color(0, 0, 255), Gradient(), ColorMode::Solid),
-      EmotionDefinition("Angry", "/anims/angry.gif", Color(255, 0, 0), Gradient(), ColorMode::Solid)
   });
 }
 

--- a/src/EmotionState.cpp
+++ b/src/EmotionState.cpp
@@ -7,7 +7,7 @@ EmotionState::EmotionState()
       tiltSideEmotion_("/anims/confused.gif")
 {
   seedEmotionDefinitions({
-      EmotionDefinition("Blush", "/anims/blush.gif", Color(255, 192, 203), Gradient(), ColorMode::Gradient),
+      EmotionDefinition("Blush", "/anims/blush.gif", Color(0, 0, 0), Gradient(Color(0, 0, 0), Color(255, 192, 203), 1.0f, 0.0f, 0.5f), ColorMode::Gradient),
       EmotionDefinition("Cute", "/anims/cute.gif", Color(255, 192, 203), Gradient(), ColorMode::Solid),
       EmotionDefinition("Evil", "/anims/evil.gif", Color(0, 0, 0), Gradient(), ColorMode::Solid),
       EmotionDefinition("Happy", "/anims/happy.gif", Color(255, 255, 0), Gradient(), ColorMode::Solid),

--- a/src/EmotionState.cpp
+++ b/src/EmotionState.cpp
@@ -1,13 +1,37 @@
 #include "EmotionState.hpp"
 
+namespace {
+EmotionState::EarColor MakeSolidEarColor(const String &hex)
+{
+  EmotionState::EarColor earColor;
+  earColor.type = EmotionState::EarColor::Type::Solid;
+  earColor.solidColor = hex;
+  return earColor;
+}
+} // namespace
+
 EmotionState::EmotionState()
     : currentEmotion_("/anims/neutral.gif"),
       previousEmotion_("/anims/neutral.gif"),
       tiltUpEmotion_("/anims/happy.gif"),
-      tiltSideEmotion_("/anims/confused.gif") {}
+      tiltSideEmotion_("/anims/confused.gif")
+{
+  seedEmotionDefinitions({
+      {"neutral", "/anims/neutral.gif", MakeSolidEarColor("#ffffff")},
+      {"happy", "/anims/happy.gif", MakeSolidEarColor("#fff36b")},
+      {"sad", "/anims/sad.gif", MakeSolidEarColor("#6bb4ff")},
+      {"evil", "/anims/evil.gif", MakeSolidEarColor("#ff6767")},
+      {"blush", "/anims/blush.gif", MakeSolidEarColor("#ff99b8")},
+  });
+}
 
 const String EmotionState::getDisplayEmotion() const
 {
+  const EmotionDefinition *emotion = getCurrentEmotionDefinition();
+  if (emotion != nullptr && emotion->name.length())
+  {
+    return emotion->name;
+  }
   return FileHelper::GetNameOnly(currentEmotion_);
 }
 
@@ -24,6 +48,21 @@ const String &EmotionState::getPreviousEmotion() const
 void EmotionState::setCurrentEmotion(const String &emotionName)
 {
   previousEmotion_ = currentEmotion_;
+
+  const EmotionDefinition *byName = getEmotionDefinitionByName(emotionName);
+  if (byName != nullptr)
+  {
+    currentEmotion_ = byName->path;
+    return;
+  }
+
+  const EmotionDefinition *byPath = getEmotionDefinitionByPath(emotionName);
+  if (byPath != nullptr)
+  {
+    currentEmotion_ = byPath->path;
+    return;
+  }
+
   currentEmotion_ = emotionName;
 }
 
@@ -45,4 +84,114 @@ void EmotionState::setTiltUpEmotion(const String &emotionName)
 void EmotionState::setTiltSideEmotion(const String &emotionName)
 {
   tiltSideEmotion_ = emotionName;
+}
+
+const std::vector<EmotionState::EmotionDefinition> &EmotionState::getEmotionDefinitions() const
+{
+  return emotionDefinitions_;
+}
+
+const EmotionState::EmotionDefinition *EmotionState::getEmotionDefinitionByName(const String &name) const
+{
+  const int index = findEmotionIndexByName(name);
+  if (index < 0)
+  {
+    return nullptr;
+  }
+  return &emotionDefinitions_[static_cast<size_t>(index)];
+}
+
+const EmotionState::EmotionDefinition *EmotionState::getEmotionDefinitionByPath(const String &path) const
+{
+  const int index = findEmotionIndexByPath(path);
+  if (index < 0)
+  {
+    return nullptr;
+  }
+  return &emotionDefinitions_[static_cast<size_t>(index)];
+}
+
+const EmotionState::EmotionDefinition *EmotionState::getCurrentEmotionDefinition() const
+{
+  return getEmotionDefinitionByPath(currentEmotion_);
+}
+
+bool EmotionState::upsertEmotionDefinition(const EmotionDefinition &emotion, bool overwriteExisting)
+{
+  const int nameIndex = findEmotionIndexByName(emotion.name);
+  if (nameIndex >= 0)
+  {
+    if (!overwriteExisting)
+    {
+      return false;
+    }
+    emotionDefinitions_[static_cast<size_t>(nameIndex)] = emotion;
+    return true;
+  }
+
+  const int pathIndex = findEmotionIndexByPath(emotion.path);
+  if (pathIndex >= 0)
+  {
+    if (!overwriteExisting)
+    {
+      return false;
+    }
+    emotionDefinitions_[static_cast<size_t>(pathIndex)] = emotion;
+    return true;
+  }
+
+  emotionDefinitions_.push_back(emotion);
+  return true;
+}
+
+bool EmotionState::removeEmotionDefinitionByName(const String &name)
+{
+  const int index = findEmotionIndexByName(name);
+  if (index < 0)
+  {
+    return false;
+  }
+
+  const String removedPath = emotionDefinitions_[static_cast<size_t>(index)].path;
+  emotionDefinitions_.erase(emotionDefinitions_.begin() + index);
+
+  if (currentEmotion_ == removedPath)
+  {
+    currentEmotion_ = previousEmotion_;
+  }
+
+  return true;
+}
+
+void EmotionState::seedEmotionDefinitions(const std::vector<EmotionDefinition> &emotions)
+{
+  emotionDefinitions_.clear();
+  for (const auto &emotion : emotions)
+  {
+    emotionDefinitions_.push_back(emotion);
+  }
+}
+
+int EmotionState::findEmotionIndexByName(const String &name) const
+{
+  for (size_t index = 0; index < emotionDefinitions_.size(); ++index)
+  {
+    if (emotionDefinitions_[index].name == name)
+    {
+      return static_cast<int>(index);
+    }
+  }
+  return -1;
+}
+
+int EmotionState::findEmotionIndexByPath(const String &path) const
+{
+  for (size_t index = 0; index < emotionDefinitions_.size(); ++index)
+  {
+    if (emotionDefinitions_[index].path == path)
+    {
+      return static_cast<int>(index);
+    }
+  }
+  return -1;
 }

--- a/src/EmotionState.hpp
+++ b/src/EmotionState.hpp
@@ -6,34 +6,10 @@
 #include <vector>
 
 #include "float_helper.hpp"
+#include "Model/EmotionDefinition.hpp"
 
 class EmotionState {
 public:
-  struct EarGradient {
-    String fromColor = "#ffffff";
-    String toColor = "#ffffff";
-    float directionX = 1.0f;
-    float directionY = 0.0f;
-    float midpoint = 0.5f;
-  };
-
-  struct EarColor {
-    enum class Type {
-      Solid,
-      Gradient,
-    };
-
-    Type type = Type::Solid;
-    String solidColor = "#ffffff";
-    EarGradient gradient;
-  };
-
-  struct EmotionDefinition {
-    String name;
-    String path;
-    EarColor earColor;
-  };
-
   EmotionState();
 
   const String &getCurrentEmotion() const;

--- a/src/EmotionState.hpp
+++ b/src/EmotionState.hpp
@@ -3,10 +3,37 @@
 
 #include <Arduino.h>
 
+#include <vector>
+
 #include "float_helper.hpp"
 
 class EmotionState {
 public:
+  struct EarGradient {
+    String fromColor = "#ffffff";
+    String toColor = "#ffffff";
+    float directionX = 1.0f;
+    float directionY = 0.0f;
+    float midpoint = 0.5f;
+  };
+
+  struct EarColor {
+    enum class Type {
+      Solid,
+      Gradient,
+    };
+
+    Type type = Type::Solid;
+    String solidColor = "#ffffff";
+    EarGradient gradient;
+  };
+
+  struct EmotionDefinition {
+    String name;
+    String path;
+    EarColor earColor;
+  };
+
   EmotionState();
 
   const String &getCurrentEmotion() const;
@@ -21,11 +48,23 @@ public:
   void setTiltUpEmotion(const String &emotionName);
   void setTiltSideEmotion(const String &emotionName);
 
+  const std::vector<EmotionDefinition> &getEmotionDefinitions() const;
+  const EmotionDefinition *getEmotionDefinitionByName(const String &name) const;
+  const EmotionDefinition *getEmotionDefinitionByPath(const String &path) const;
+  const EmotionDefinition *getCurrentEmotionDefinition() const;
+  bool upsertEmotionDefinition(const EmotionDefinition &emotion, bool overwriteExisting);
+  bool removeEmotionDefinitionByName(const String &name);
+  void seedEmotionDefinitions(const std::vector<EmotionDefinition> &emotions);
+
 private:
+  int findEmotionIndexByName(const String &name) const;
+  int findEmotionIndexByPath(const String &path) const;
+
   String currentEmotion_;
   String previousEmotion_;
   String tiltUpEmotion_;
   String tiltSideEmotion_;
+  std::vector<EmotionDefinition> emotionDefinitions_;
 };
 
 #endif // EMOTION_STATE_HPP

--- a/src/Graphics/Brightness.cpp
+++ b/src/Graphics/Brightness.cpp
@@ -1,0 +1,25 @@
+#include "Brightness.hpp"
+
+Brightness::Brightness(uint8_t value) : value_(value) {}
+
+void Brightness::setValue(uint8_t value) {
+  value_ = value;
+}
+
+uint8_t Brightness::getValue() const {
+  return value_;
+}
+
+void Brightness::setPercent(float percent) {
+  float clamped = percent;
+  if (clamped < kMinBrightnessPercent) {
+    clamped = kMinBrightnessPercent;
+  } else if (clamped > kMaxBrightnessPercent) {
+    clamped = kMaxBrightnessPercent;
+  }
+  value_ = static_cast<uint8_t>(roundf(clamped * kPercentToByte));
+}
+
+float Brightness::getPercent() const {
+  return (static_cast<float>(value_) / 255.0f) * 100.0f;
+}

--- a/src/Graphics/Brightness.hpp
+++ b/src/Graphics/Brightness.hpp
@@ -1,0 +1,23 @@
+#ifndef BRIGHTNESS_HPP
+#define BRIGHTNESS_HPP
+
+#include <Arduino.h>
+
+class Brightness {
+  public:
+    const float kMaxBrightnessPercent = 100.0f;
+    const float kMinBrightnessPercent = 0.0f;
+    const float kPercentToByte = 255.0f / 100.0f;
+
+    explicit Brightness(uint8_t value = 80);
+
+    void setValue(uint8_t value);
+    uint8_t getValue() const;
+    void setPercent(float percent);
+    float getPercent() const;
+    
+  private:
+    uint8_t value_;
+  };
+
+#endif // BRIGHTNESS_HPP

--- a/src/Graphics/Color.cpp
+++ b/src/Graphics/Color.cpp
@@ -1,0 +1,67 @@
+#include "Color.hpp"
+
+Color::Color(uint8_t r, uint8_t g, uint8_t b)
+{
+    red = r;
+    green = g;
+    blue = b;
+}
+
+void Color::set(uint8_t r, uint8_t g, uint8_t b)
+{
+    red = r;
+    green = g;
+    blue = b;
+}
+
+uint8_t Color::getRed() const
+{
+    return red;
+}
+
+uint8_t Color::getGreen() const
+{
+    return green;
+};
+
+uint8_t Color::getBlue() const
+{
+    return blue;
+};
+
+String Color::toHexString() const
+{
+    char buffer[8];
+    snprintf(buffer, sizeof(buffer), "#%02x%02x%02x", red, green, blue);
+    return String(buffer);
+}
+
+bool Color::setFromHex(const String &hex)
+{
+    if (hex.length() != 7 || hex.charAt(0) != '#')
+    {
+        return false;
+    }
+
+    auto parseComponent = [&hex](uint8_t start) -> int
+    {
+        String component = hex.substring(start, start + 2);
+        long value = strtol(component.c_str(), nullptr, 16);
+        if (value < 0 || value > 255)
+        {
+            return -1;
+        }
+        return static_cast<int>(value);
+    };
+
+    const int r = parseComponent(1);
+    const int g = parseComponent(3);
+    const int b = parseComponent(5);
+    if (r < 0 || g < 0 || b < 0)
+    {
+        return false;
+    }
+
+    set(static_cast<uint8_t>(r), static_cast<uint8_t>(g), static_cast<uint8_t>(b));
+    return true;
+}

--- a/src/Graphics/Color.cpp
+++ b/src/Graphics/Color.cpp
@@ -1,5 +1,7 @@
 #include "Color.hpp"
 
+Color::Color() : red(0), green(0), blue(0) {}
+
 Color::Color(uint8_t r, uint8_t g, uint8_t b)
 {
     red = r;

--- a/src/Graphics/Color.hpp
+++ b/src/Graphics/Color.hpp
@@ -1,0 +1,22 @@
+#ifndef COLOR_HPP
+#define COLOR_HPP
+
+ #include <Arduino.h>
+
+struct Color {
+  public:
+    uint8_t getRed() const;
+    uint8_t getGreen() const;
+    uint8_t getBlue() const;
+
+    explicit Color(uint8_t r, uint8_t g, uint8_t b);
+    void set(uint8_t r, uint8_t g, uint8_t b);
+    String toHexString() const;
+    bool setFromHex(const String &hex);
+  private:
+    uint8_t red = 255;
+    uint8_t green = 255;
+    uint8_t blue = 255;
+  };
+
+  #endif //COLOR_HPP

--- a/src/Graphics/Color.hpp
+++ b/src/Graphics/Color.hpp
@@ -9,7 +9,8 @@ struct Color {
     uint8_t getGreen() const;
     uint8_t getBlue() const;
 
-    explicit Color(uint8_t r, uint8_t g, uint8_t b);
+    explicit Color();
+    Color(uint8_t r, uint8_t g, uint8_t b);
     void set(uint8_t r, uint8_t g, uint8_t b);
     String toHexString() const;
     bool setFromHex(const String &hex);

--- a/src/Graphics/Gradient.cpp
+++ b/src/Graphics/Gradient.cpp
@@ -1,0 +1,107 @@
+#include "Gradient.hpp"
+
+Gradient::Gradient() : from(255, 255, 255), to(255, 255, 255), directionX(1.0f), directionY(0.0f), midpoint(0.5f) {}
+
+float Gradient::clampUnit(float value) const
+    {
+        if (value < 0.0f)
+        {
+            return 0.0f;
+        }
+        if (value > 1.0f)
+        {
+            return 1.0f;
+        }
+        return value;
+    }
+
+uint8_t Gradient::interpolateComponent(uint8_t from, uint8_t to, float factor) const
+{
+    const float start = static_cast<float>(from);
+    const float end = static_cast<float>(to);
+    const float value = start + ((end - start) * clampUnit(factor));
+    return static_cast<uint8_t>(roundf(value));
+}
+
+bool Gradient::setFromHex(
+    const String &fromHex, 
+    const String &toHex, 
+    float directionX, 
+    float directionY, 
+    float midpoint)
+{
+  if (!from.setFromHex(fromHex) || !to.setFromHex(toHex))
+  {
+    return false;
+  }
+  directionX = directionX;
+  directionY = directionY;
+  midpoint = clampUnit(midpoint);
+
+  return true;
+}
+
+Color Gradient::rasterizeColor(int index, int length) const
+{
+    float position = length > 1
+                         ? static_cast<float>(index) / static_cast<float>(length - 1)
+                         : 0.0f;
+
+      const float directionInfluence = (this->directionX + this->directionY) * 0.5f;
+      position = clampUnit(position + (directionInfluence * 0.25f));
+
+      float blend = 0.0f;
+      if (this->midpoint <= 0.0f)
+      {
+        blend = 1.0f;
+      }
+      else if (this->midpoint >= 1.0f)
+      {
+        blend = 0.0f;
+      }
+      else
+      {
+        blend = position / this->midpoint;
+      }
+      blend = clampUnit(blend);
+
+      const uint8_t red = interpolateComponent(from.getRed(), to.getRed(), blend);
+      const uint8_t green = interpolateComponent(from.getGreen(), to.getGreen(), blend);
+      const uint8_t blue = interpolateComponent(from.getBlue(), to.getBlue(), blend);
+
+      Color color(red, green, blue);
+      return color;
+}
+
+void Gradient::serialize(JsonVariant gradientJson) const {
+  if (gradientJson.isNull()) {
+    return;
+  }
+
+  gradientJson["from"] = from.toHexString();
+  gradientJson["to"] = to.toHexString();
+  gradientJson["directionX"] = directionX;
+  gradientJson["directionY"] = directionY;
+  gradientJson["midpoint"] = midpoint;
+}
+
+bool Gradient::deserialize(const JsonObject &obj, String &error)
+{
+  if (!obj.containsKey("from") || !obj.containsKey("to")) {
+    error = "Missing required 'from' or 'to' color fields.";
+    return false;
+  }
+
+  String fromHex = obj["from"].as<String>();
+  String toHex = obj["to"].as<String>();
+  float directionX = obj.containsKey("directionX") ? obj["directionX"].as<float>() : 1.0f;
+  float directionY = obj.containsKey("directionY") ? obj["directionY"].as<float>() : 0.0f;
+  float midpoint = obj.containsKey("midpoint") ? obj["midpoint"].as<float>() : 0.5f;
+
+  if (!setFromHex(fromHex, toHex, directionX, directionY, midpoint)) {
+    error = "Invalid color format. Use #RRGGBB.";
+    return false;
+  }
+
+  return true;
+}

--- a/src/Graphics/Gradient.cpp
+++ b/src/Graphics/Gradient.cpp
@@ -2,32 +2,39 @@
 
 Gradient::Gradient() : from(255, 255, 255), to(255, 255, 255), directionX(1.0f), directionY(0.0f), midpoint(0.5f) {}
 
+Gradient::Gradient(const Color &from, const Color &to, float directionX, float directionY, float midpoint)
+    : from(from),
+      to(to),
+      directionX(directionX),
+      directionY(directionY),
+      midpoint(midpoint) {}
+
 float Gradient::clampUnit(float value) const
-    {
-        if (value < 0.0f)
-        {
-            return 0.0f;
-        }
-        if (value > 1.0f)
-        {
-            return 1.0f;
-        }
-        return value;
-    }
+{
+  if (value < 0.0f)
+  {
+    return 0.0f;
+  }
+  if (value > 1.0f)
+  {
+    return 1.0f;
+  }
+  return value;
+}
 
 uint8_t Gradient::interpolateComponent(uint8_t from, uint8_t to, float factor) const
 {
-    const float start = static_cast<float>(from);
-    const float end = static_cast<float>(to);
-    const float value = start + ((end - start) * clampUnit(factor));
-    return static_cast<uint8_t>(roundf(value));
+  const float start = static_cast<float>(from);
+  const float end = static_cast<float>(to);
+  const float value = start + ((end - start) * clampUnit(factor));
+  return static_cast<uint8_t>(roundf(value));
 }
 
 bool Gradient::setFromHex(
-    const String &fromHex, 
-    const String &toHex, 
-    float directionX, 
-    float directionY, 
+    const String &fromHex,
+    const String &toHex,
+    float directionX,
+    float directionY,
     float midpoint)
 {
   if (!from.setFromHex(fromHex) || !to.setFromHex(toHex))
@@ -43,38 +50,40 @@ bool Gradient::setFromHex(
 
 Color Gradient::rasterizeColor(int index, int length) const
 {
-    float position = length > 1
-                         ? static_cast<float>(index) / static_cast<float>(length - 1)
-                         : 0.0f;
+  float position = length > 1
+                       ? static_cast<float>(index) / static_cast<float>(length - 1)
+                       : 0.0f;
 
-      const float directionInfluence = (this->directionX + this->directionY) * 0.5f;
-      position = clampUnit(position + (directionInfluence * 0.25f));
+  const float directionInfluence = (this->directionX + this->directionY) * 0.5f;
+  position = clampUnit(position + (directionInfluence * 0.25f));
 
-      float blend = 0.0f;
-      if (this->midpoint <= 0.0f)
-      {
-        blend = 1.0f;
-      }
-      else if (this->midpoint >= 1.0f)
-      {
-        blend = 0.0f;
-      }
-      else
-      {
-        blend = position / this->midpoint;
-      }
-      blend = clampUnit(blend);
+  float blend = 0.0f;
+  if (this->midpoint <= 0.0f)
+  {
+    blend = 1.0f;
+  }
+  else if (this->midpoint >= 1.0f)
+  {
+    blend = 0.0f;
+  }
+  else
+  {
+    blend = position / this->midpoint;
+  }
+  blend = clampUnit(blend);
 
-      const uint8_t red = interpolateComponent(from.getRed(), to.getRed(), blend);
-      const uint8_t green = interpolateComponent(from.getGreen(), to.getGreen(), blend);
-      const uint8_t blue = interpolateComponent(from.getBlue(), to.getBlue(), blend);
+  const uint8_t red = interpolateComponent(from.getRed(), to.getRed(), blend);
+  const uint8_t green = interpolateComponent(from.getGreen(), to.getGreen(), blend);
+  const uint8_t blue = interpolateComponent(from.getBlue(), to.getBlue(), blend);
 
-      Color color(red, green, blue);
-      return color;
+  Color color(red, green, blue);
+  return color;
 }
 
-void Gradient::serialize(JsonVariant gradientJson) const {
-  if (gradientJson.isNull()) {
+void Gradient::serialize(JsonVariant gradientJson) const
+{
+  if (gradientJson.isNull())
+  {
     return;
   }
 
@@ -87,7 +96,8 @@ void Gradient::serialize(JsonVariant gradientJson) const {
 
 bool Gradient::deserialize(const JsonObject &obj, String &error)
 {
-  if (!obj.containsKey("from") || !obj.containsKey("to")) {
+  if (!obj.containsKey("from") || !obj.containsKey("to"))
+  {
     error = "Missing required 'from' or 'to' color fields.";
     return false;
   }
@@ -98,7 +108,8 @@ bool Gradient::deserialize(const JsonObject &obj, String &error)
   float directionY = obj.containsKey("directionY") ? obj["directionY"].as<float>() : 0.0f;
   float midpoint = obj.containsKey("midpoint") ? obj["midpoint"].as<float>() : 0.5f;
 
-  if (!setFromHex(fromHex, toHex, directionX, directionY, midpoint)) {
+  if (!setFromHex(fromHex, toHex, directionX, directionY, midpoint))
+  {
     error = "Invalid color format. Use #RRGGBB.";
     return false;
   }

--- a/src/Graphics/Gradient.hpp
+++ b/src/Graphics/Gradient.hpp
@@ -1,0 +1,34 @@
+#ifndef GRADIENT_HPP
+#define GRADIENT_HPP
+
+#include <ArduinoJson.h>
+
+#include "Color.hpp"
+
+struct Gradient
+{
+  Color from;
+  Color to;
+  float directionX = 1.0f;
+  float directionY = 0.0f;
+  float midpoint = 0.5f;
+
+public:
+  explicit Gradient();
+  Color rasterizeColor(int position, int length) const;
+  bool setFromHex(const String &fromHex, const String &toHex, float directionX, float directionY, float midpoint);
+  void serialize(JsonVariant gradientJson) const;
+  bool deserialize(const JsonObject &obj, String &error);
+
+  private:
+  float clampUnit(float value) const;
+  uint8_t interpolateComponent(uint8_t from, uint8_t to, float factor) const;
+};
+
+enum class ColorMode
+{
+  Solid,
+  Gradient,
+};
+
+#endif // GRADIENT_HPP

--- a/src/Graphics/Gradient.hpp
+++ b/src/Graphics/Gradient.hpp
@@ -15,6 +15,7 @@ struct Gradient
 
 public:
   explicit Gradient();
+  Gradient(const Color &from, const Color &to, float directionX, float directionY, float midpoint);
   Color rasterizeColor(int position, int length) const;
   bool setFromHex(const String &fromHex, const String &toHex, float directionX, float directionY, float midpoint);
   void serialize(JsonVariant gradientJson) const;

--- a/src/Model/AnimationFile.cpp
+++ b/src/Model/AnimationFile.cpp
@@ -1,0 +1,31 @@
+#include "AnimationFile.hpp"
+
+void AnimationFile::serialize(JsonVariant json) const
+{
+    if (json.isNull())
+    {
+        return;
+    }
+
+    json["name"] = name;
+    json["path"] = path;
+}
+
+bool AnimationFile::deserialize(const JsonObject &object, String &error)
+{
+    if (!object.containsKey("name") || !object["name"].is<String>())
+    {
+        error = F("AnimationFile 'name' is required and must be a string.");
+        return false;
+    }
+    name = object["name"].as<String>();
+
+    if (!object.containsKey("path") || !object["path"].is<String>())
+    {
+        error = F("AnimationFile 'path' is required and must be a string.");
+        return false;
+    }
+    path = object["path"].as<String>();
+
+    return true;
+}

--- a/src/Model/AnimationFile.hpp
+++ b/src/Model/AnimationFile.hpp
@@ -1,0 +1,16 @@
+
+#ifndef ANIMATION_FILE_HPP
+#define ANIMATION_FILE_HPP
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+  
+struct AnimationFile {
+    String name;
+    String path;
+
+    void serialize(JsonVariant json) const;
+    bool deserialize(const JsonObject &object, String &error);
+};
+
+#endif //ANIMATION_FILE_HPP

--- a/src/Model/Ear.cpp
+++ b/src/Model/Ear.cpp
@@ -10,7 +10,7 @@ void Ear::setColor(uint8_t red, uint8_t green, uint8_t blue) {
 void Ear::setColor(const Color &color)
 {
   color_ = color;
-  colorMode_ = ColorMode::Gradient;
+  colorMode_ = ColorMode::Solid;
 }
 
 bool Ear::setColorFromHex(const String &hex) {

--- a/src/Model/Ear.cpp
+++ b/src/Model/Ear.cpp
@@ -1,0 +1,87 @@
+#include "Ear.hpp"
+
+Ear::Ear() : color_(0,0,0), gradient_(), colorMode_(ColorMode::Solid), brightness_() {}
+
+void Ear::setColor(uint8_t red, uint8_t green, uint8_t blue) {
+  color_.set(red, green, blue);
+  colorMode_ = ColorMode::Solid;
+}
+
+void Ear::setColor(const Color &color)
+{
+  color_ = color;
+  colorMode_ = ColorMode::Gradient;
+}
+
+bool Ear::setColorFromHex(const String &hex) {
+  if (!color_.setFromHex(hex)) {
+    return false;
+  }
+  colorMode_ = ColorMode::Solid;
+  return true;
+}
+
+const Color &Ear::getColor() const {
+  return color_;
+}
+
+String Ear::getColorHexString() const {
+  return color_.toHexString();
+}
+
+bool Ear::setGradientFromHex(const String &fromHex, const String &toHex,
+                          float directionX, float directionY,
+                          float midpoint)
+{
+    if (!gradient_.setFromHex(fromHex, toHex, directionX, directionY, midpoint)) {
+        return false;
+    }
+    colorMode_ = ColorMode::Solid;
+    return true;
+}
+
+void Ear::setGradient(const Gradient &gradient)
+{
+  gradient_ = gradient;
+  colorMode_ = ColorMode::Gradient;
+}
+
+const Gradient &Ear::getGradient() const
+{
+  return gradient_;
+}
+
+ColorMode Ear::getColorMode() const
+{
+  return colorMode_;
+}
+
+void Ear::setBrightness(uint8_t brightness) {
+  brightness_.setValue(brightness);
+}
+
+void Ear::setBrightnessPercent(float percent) {
+  brightness_.setPercent(percent);
+}
+
+uint8_t Ear::getBrightness() const {
+  return brightness_.getValue();
+}
+
+float Ear::getBrightnessPercent() const {
+  return brightness_.getPercent();
+}
+
+void Ear::serialize(JsonVariant json) const {
+  if (json.isNull()) {
+    return;
+  }
+
+  json["mode"] = colorMode_ == ColorMode::Gradient ? "gradient" : "solid";
+  json["color"] = getColorHexString();
+  json["brightness"] = getBrightness();
+  json["brightnessPercent"] = getBrightnessPercent();
+
+  JsonObject gradientJson = json["gradient"].to<JsonObject>();
+  gradient_.serialize(gradientJson);
+}

--- a/src/Model/Ear.hpp
+++ b/src/Model/Ear.hpp
@@ -1,0 +1,43 @@
+#ifndef EAR_HPP
+#define EAR_HPP
+
+#include <ArduinoJson.h>
+
+#include "../Graphics/Brightness.hpp"
+#include "../Graphics/Color.hpp"
+#include "../Graphics/Gradient.hpp"
+
+class Ear {
+public:
+  Ear();
+
+  void setColor(uint8_t red, uint8_t green, uint8_t blue);
+  void setColor(const Color &color);
+  bool setColorFromHex(const String &hex);
+  const Color &getColor() const;
+  String getColorHexString() const;
+
+  bool setGradientFromHex(const String &fromHex, const String &toHex,
+                          float directionX, float directionY,
+                          float midpoint);
+  void setGradient(const Gradient &gradient);
+  const Gradient &getGradient() const;
+
+  void setColorMode(ColorMode mode);
+  ColorMode getColorMode() const;
+
+  void setBrightness(uint8_t brightness);
+  void setBrightnessPercent(float percent);
+  uint8_t getBrightness() const;
+  float getBrightnessPercent() const;
+
+  void serialize(JsonVariant json) const;
+
+private:
+  Color color_;
+  Gradient gradient_;
+  ColorMode colorMode_;
+  Brightness brightness_;
+};
+
+#endif

--- a/src/Model/EmotionDefinition.cpp
+++ b/src/Model/EmotionDefinition.cpp
@@ -1,0 +1,85 @@
+#include "EmotionDefinition.hpp"
+
+EmotionDefinition::EmotionDefinition()
+    : name(""),
+      path(""),
+      earColor(Color(0, 0, 0)),
+      earGradient(Gradient()),
+      earColorMode(ColorMode::Solid)
+{
+}
+
+EmotionDefinition::EmotionDefinition(const String &name, const String &path, const Color &earColor, const Gradient &earGradient, ColorMode earColorMode)
+    : name(name),
+      path(path),
+      earColor(earColor),
+      earGradient(earGradient),
+      earColorMode(earColorMode)
+{
+}
+
+void EmotionDefinition::serialize(JsonVariant object) const
+{
+    if (object.isNull())
+    {
+        return;
+    }
+
+    object["name"] = name;
+    object["path"] = path;
+
+    auto gradient = object["gradient"].to<JsonObject>();
+    earGradient.serialize(gradient);
+
+    object["earColorMode"] = earColorMode == ColorMode::Gradient
+                                 ? "gradient"
+                                 : "solid";
+
+    object["earColor"] = earColor.toHexString();
+}
+
+bool EmotionDefinition::deserialize(const JsonObject &object, String &error)
+{
+    if (!object.containsKey("name") || !object["name"].is<String>())
+    {
+        error = F("Emotion 'name' is required and must be a string.");
+        return false;
+    }
+    name = object["name"].as<String>();
+
+    if (!object.containsKey("path") || !object["path"].is<String>())
+    {
+        error = F("Emotion 'path' is required and must be a string.");
+        return false;
+    }
+    path = object["path"].as<String>();
+
+    if (object.containsKey("earColorMode"))
+    {
+        String modeStr = object["earColorMode"].as<String>();
+        earColorMode = modeStr == "gradient"
+                           ? ColorMode::Gradient
+                           : ColorMode::Solid;
+    }
+
+    if (object.containsKey("earColor"))
+    {
+        String colorHex = object["earColor"].as<String>();
+        if (!earColor.setFromHex(colorHex))
+        {
+            error = F("Invalid 'earColor' hex string.");
+            return false;
+        }
+    }
+
+    if (object.containsKey("gradient") && object["gradient"].is<JsonObject>())
+    {
+        JsonObject gradientObj = object["gradient"].as<JsonObject>();
+        if (!earGradient.deserialize(gradientObj, error))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/Model/EmotionDefinition.hpp
+++ b/src/Model/EmotionDefinition.hpp
@@ -1,0 +1,23 @@
+#ifndef EMOTIONDEFINITION_HPP
+#define EMOTIONDEFINITION_HPP
+
+#include <Arduino.h>
+
+#include "../Graphics/Brightness.hpp"
+#include "../Graphics/Color.hpp"
+#include "../Graphics/Gradient.hpp"
+  
+struct EmotionDefinition {
+    String name;
+    String path;
+    Color earColor;
+    Gradient earGradient;
+    ColorMode earColorMode;
+
+    EmotionDefinition();
+    EmotionDefinition(const String &name, const String &path, const Color &earColor, const Gradient &earGradient, ColorMode earColorMode);
+    void serialize(JsonVariant json) const;
+    bool deserialize(const JsonObject &object, String &error);
+};
+
+#endif //EMOTIONDEFINITION_HPP

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1,16 +1,154 @@
 #include "WebServerManager.hpp"
 
-#include <vector>
 #include <ArduinoJson.h>
 #include <FS.h>
+#include <vector>
+
+namespace {
+bool parseEmotionDefinitionJson(const String &jsonPayload,
+                                EmotionState::EmotionDefinition &emotion,
+                                String &error)
+{
+  JsonDocument doc;
+  DeserializationError parseError = deserializeJson(doc, jsonPayload);
+  if (parseError)
+  {
+    error = "Invalid JSON payload.";
+    return false;
+  }
+
+  JsonVariant root = doc.as<JsonVariant>();
+  if (!root.is<JsonObject>())
+  {
+    error = "Payload must be an object.";
+    return false;
+  }
+
+  emotion.name = root["name"] | "";
+  emotion.path = root["path"] | "";
+  if (emotion.name.isEmpty() || emotion.path.isEmpty())
+  {
+    error = "Emotion requires non-empty 'name' and 'path'.";
+    return false;
+  }
+
+  JsonVariant earColorJson = root["earColor"];
+  if (earColorJson.isNull() || !earColorJson.is<JsonObject>())
+  {
+    error = "Emotion requires 'earColor' object.";
+    return false;
+  }
+
+  const String type = earColorJson["type"] | "";
+  if (type == "solid")
+  {
+    const String color = earColorJson["color"] | "";
+    emotion.earColor.type = EmotionState::EarColor::Type::Solid;
+    emotion.earColor.solidColor = color;
+    if (color.length() != 7 || color.charAt(0) != '#')
+    {
+      error = "Solid earColor.color must be in #RRGGBB format.";
+      return false;
+    }
+  }
+  else if (type == "gradient")
+  {
+    JsonVariant gradientJson = earColorJson["gradient"];
+    if (gradientJson.isNull() || !gradientJson.is<JsonObject>())
+    {
+      error = "Gradient earColor requires gradient object.";
+      return false;
+    }
+
+    const String from = gradientJson["from"] | "";
+    const String to = gradientJson["to"] | "";
+    if (from.length() != 7 || to.length() != 7 || from.charAt(0) != '#' || to.charAt(0) != '#')
+    {
+      error = "Gradient colors must be in #RRGGBB format.";
+      return false;
+    }
+
+    emotion.earColor.type = EmotionState::EarColor::Type::Gradient;
+    emotion.earColor.gradient.fromColor = from;
+    emotion.earColor.gradient.toColor = to;
+    emotion.earColor.gradient.directionX = gradientJson["directionX"] | 1.0f;
+    emotion.earColor.gradient.directionY = gradientJson["directionY"] | 0.0f;
+    emotion.earColor.gradient.midpoint = gradientJson["midpoint"] | 0.5f;
+    if (emotion.earColor.gradient.midpoint < 0.0f || emotion.earColor.gradient.midpoint > 1.0f)
+    {
+      error = "Gradient midpoint must be within [0,1].";
+      return false;
+    }
+  }
+  else
+  {
+    error = "earColor.type must be either 'solid' or 'gradient'.";
+    return false;
+  }
+
+  return true;
+}
+
+void serializeEmotionDefinition(JsonArray array, const EmotionState::EmotionDefinition &emotion)
+{
+  JsonObject emotionObject = array.add<JsonObject>();
+  emotionObject["name"] = emotion.name;
+  emotionObject["path"] = emotion.path;
+
+  JsonObject earColor = emotionObject["earColor"].to<JsonObject>();
+  if (emotion.earColor.type == EmotionState::EarColor::Type::Gradient)
+  {
+    earColor["type"] = "gradient";
+    JsonObject gradient = earColor["gradient"].to<JsonObject>();
+    gradient["from"] = emotion.earColor.gradient.fromColor;
+    gradient["to"] = emotion.earColor.gradient.toColor;
+    gradient["directionX"] = emotion.earColor.gradient.directionX;
+    gradient["directionY"] = emotion.earColor.gradient.directionY;
+    gradient["midpoint"] = emotion.earColor.gradient.midpoint;
+  }
+  else
+  {
+    earColor["type"] = "solid";
+    earColor["color"] = emotion.earColor.solidColor;
+  }
+}
+
+void applyEmotionEarColor(EarController &earController,
+                          const EmotionState::EmotionDefinition *emotion)
+{
+  if (emotion == nullptr)
+  {
+    return;
+  }
+
+  Ear &ear = earController.getEar();
+  if (emotion->earColor.type == EmotionState::EarColor::Type::Gradient)
+  {
+    if (!ear.setGradientFromHex(
+            emotion->earColor.gradient.fromColor,
+            emotion->earColor.gradient.toColor,
+            emotion->earColor.gradient.directionX,
+            emotion->earColor.gradient.directionY,
+            emotion->earColor.gradient.midpoint))
+    {
+      Serial.println(F("[E] Could not apply gradient ear color from emotion."));
+    }
+    return;
+  }
+
+  if (!ear.setColorFromHex(emotion->earColor.solidColor))
+  {
+    Serial.println(F("[E] Could not apply solid ear color from emotion."));
+  }
+}
+} // namespace
 
 WebServerManager::WebServerManager(
-  EmotionState &emotionState, 
-  FanController &fanController,
-  EarController &earController, 
-  TiltController &tiltController,
-  AnimationManager &animationManager
-)
+    EmotionState &emotionState,
+    FanController &fanController,
+    EarController &earController,
+    TiltController &tiltController,
+    AnimationManager &animationManager)
     : server_(80),
       emotionState_(emotionState),
       fanController_(fanController),
@@ -18,7 +156,8 @@ WebServerManager::WebServerManager(
       tiltController_(tiltController),
       animationManager_(animationManager) {}
 
-void WebServerManager::begin(const char *ssid, const char *password) {
+void WebServerManager::begin(const char *ssid, const char *password)
+{
   WiFi.softAP(ssid, password);
 
   registerRoutes();
@@ -28,30 +167,38 @@ void WebServerManager::begin(const char *ssid, const char *password) {
   ElegantOTA.setAutoReboot(true);
 }
 
-void WebServerManager::loop() {
+void WebServerManager::loop()
+{
   ElegantOTA.loop();
 }
 
-void WebServerManager::registerRoutes() {
+void WebServerManager::registerRoutes()
+{
   server_.serveStatic("/", SPIFFS, "/").setDefaultFile("index.html");
 
   server_.on(
       "/file", HTTP_POST,
-      [](AsyncWebServerRequest *request) {
+      [](AsyncWebServerRequest *request)
+      {
         auto *context = static_cast<UploadContext *>(request->_tempObject);
-        if (context == nullptr) {
+        if (context == nullptr)
+        {
           request->send(400, "text/plain", F("No file uploaded."));
           return;
         }
 
         String message = context->message;
-        if (!message.length()) {
+        if (!message.length())
+        {
           message = F("File was saved.");
         }
 
-        if (context->error) {
+        if (context->error)
+        {
           request->send(400, "text/plain", message);
-        } else {
+        }
+        else
+        {
           request->send(200, "text/plain", message);
         }
 
@@ -59,12 +206,14 @@ void WebServerManager::registerRoutes() {
         request->_tempObject = nullptr;
       },
       [this](AsyncWebServerRequest *request, String filename, size_t index,
-             uint8_t *data, size_t len, bool final) {
-            Serial.println(F("[I] File upload callback called"));
+             uint8_t *data, size_t len, bool final)
+      {
+        Serial.println(F("[I] File upload callback called"));
         handleFileUpload(request, filename, index, data, len, final);
       });
 
-  server_.on("/file", HTTP_DELETE, [this](AsyncWebServerRequest *request) {
+  server_.on("/file", HTTP_DELETE, [this](AsyncWebServerRequest *request)
+             {
     if (!request->hasParam("file")) {
       request->send(400, "text/plain", F("Parameter 'file' not present!"));
       return;
@@ -84,48 +233,144 @@ void WebServerManager::registerRoutes() {
     }
 
     SPIFFS.remove(filePath);
-    request->send(200, "text/plain", F("File was deleted."));
-  });
+    request->send(200, "text/plain", F("File was deleted.")); });
 
-  server_.on("/files", HTTP_GET, [this](AsyncWebServerRequest *request) {
-    auto emotions = animationManager_.getEmotions();
-
+  server_.on("/files", HTTP_GET, [this](AsyncWebServerRequest *request)
+             {
     JsonDocument doc;
     JsonArray array = doc.to<JsonArray>();
-    for (const auto emotion : emotions) {
-      JsonDocument emotionInfo;
-      emotionInfo["name"] = emotion.name;
-      emotionInfo["path"] = emotion.path;
-      array.add(emotionInfo);
+    const auto &emotions = emotionState_.getEmotionDefinitions();
+    for (const auto &emotion : emotions) {
+      serializeEmotionDefinition(array, emotion);
     }
 
     String json;
     serializeJson(array, json);
-    request->send(200, "application/json", json);
-  });
+    request->send(200, "application/json", json); });
 
-  server_.on("/emotion", HTTP_GET, [this](AsyncWebServerRequest *request) {
-    request->send(200, "text/plain", emotionState_.getCurrentEmotion());
-  });
+  server_.on("/emotions", HTTP_GET, [this](AsyncWebServerRequest *request)
+             {
+    JsonDocument doc;
+    JsonArray array = doc.to<JsonArray>();
+    for (const auto &emotion : emotionState_.getEmotionDefinitions()) {
+      serializeEmotionDefinition(array, emotion);
+    }
 
-  server_.on("/emotion", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+    String json;
+    serializeJson(doc, json);
+    request->send(200, "application/json", json); });
+
+  server_.on("/emotion", HTTP_GET, [this](AsyncWebServerRequest *request)
+             {
+    JsonDocument doc;
+    JsonObject object = doc.to<JsonObject>();
+    const auto *emotion = emotionState_.getCurrentEmotionDefinition();
+
+    object["path"] = emotionState_.getCurrentEmotion();
+    if (emotion != nullptr) {
+      object["name"] = emotion->name;
+      JsonObject earColor = object["earColor"].to<JsonObject>();
+      if (emotion->earColor.type == EmotionState::EarColor::Type::Gradient) {
+        earColor["type"] = "gradient";
+        JsonObject gradient = earColor["gradient"].to<JsonObject>();
+        gradient["from"] = emotion->earColor.gradient.fromColor;
+        gradient["to"] = emotion->earColor.gradient.toColor;
+        gradient["directionX"] = emotion->earColor.gradient.directionX;
+        gradient["directionY"] = emotion->earColor.gradient.directionY;
+        gradient["midpoint"] = emotion->earColor.gradient.midpoint;
+      } else {
+        earColor["type"] = "solid";
+        earColor["color"] = emotion->earColor.solidColor;
+      }
+    } else {
+      object["name"] = emotionState_.getDisplayEmotion();
+    }
+
+    String json;
+    serializeJson(doc, json);
+    request->send(200, "application/json", json); });
+
+  server_.on("/emotion", HTTP_POST, [this](AsyncWebServerRequest *request)
+             {
+    if (!request->hasParam("plain", true)) {
+      request->send(400, "text/plain", F("JSON payload is required."));
+      return;
+    }
+
+    EmotionState::EmotionDefinition emotion;
+    String error;
+    if (!parseEmotionDefinitionJson(request->getParam("plain", true)->value(), emotion, error)) {
+      request->send(400, "text/plain", error);
+      return;
+    }
+
+    if (!emotionState_.upsertEmotionDefinition(emotion, false)) {
+      request->send(409, "text/plain", F("Emotion already exists."));
+      return;
+    }
+
+    request->send(201, "text/plain", F("Emotion created.")); });
+
+  server_.on("/emotion", HTTP_PUT, [this](AsyncWebServerRequest *request)
+             {
     if (request->hasParam("name", true)) {
       emotionState_.setCurrentEmotion(request->getParam("name", true)->value());
+      applyEmotionEarColor(earController_, emotionState_.getCurrentEmotionDefinition());
       request->send(200, "text/plain", F("Emotion changed."));
-    } else {
-      request->send(400, "text/plain", F("No valid parameters detected!"));
+      return;
     }
-  });
 
-  server_.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send(200, "text/plain", String(ESP.getFreeHeap()));
-  });
+    if (!request->hasParam("plain", true)) {
+      request->send(400, "text/plain", F("JSON payload is required for emotion update."));
+      return;
+    }
 
-  server_.on("/fan", HTTP_GET, [this](AsyncWebServerRequest *request) {
-    request->send(200, "text/plain", String(fanController_.getDutyCycle()));
-  });
+    EmotionState::EmotionDefinition emotion;
+    String error;
+    if (!parseEmotionDefinitionJson(request->getParam("plain", true)->value(), emotion, error)) {
+      request->send(400, "text/plain", error);
+      return;
+    }
 
-  server_.on("/fan", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+    if (emotionState_.getEmotionDefinitionByName(emotion.name) == nullptr &&
+        emotionState_.getEmotionDefinitionByPath(emotion.path) == nullptr) {
+      request->send(404, "text/plain", F("Emotion does not exist."));
+      return;
+    }
+
+    emotionState_.upsertEmotionDefinition(emotion, true);
+
+    if (emotionState_.getCurrentEmotion() == emotion.path ||
+        (emotionState_.getCurrentEmotionDefinition() != nullptr &&
+         emotionState_.getCurrentEmotionDefinition()->name == emotion.name)) {
+      applyEmotionEarColor(earController_, emotionState_.getCurrentEmotionDefinition());
+    }
+
+    request->send(200, "text/plain", F("Emotion updated.")); });
+
+  server_.on("/emotion", HTTP_DELETE, [this](AsyncWebServerRequest *request)
+             {
+    if (!request->hasParam("name")) {
+      request->send(400, "text/plain", F("Parameter 'name' is required."));
+      return;
+    }
+
+    String name = request->getParam("name")->value();
+    if (!emotionState_.removeEmotionDefinitionByName(name)) {
+      request->send(404, "text/plain", F("Emotion not found."));
+      return;
+    }
+
+    request->send(200, "text/plain", F("Emotion removed.")); });
+
+  server_.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request)
+             { request->send(200, "text/plain", String(ESP.getFreeHeap())); });
+
+  server_.on("/fan", HTTP_GET, [this](AsyncWebServerRequest *request)
+             { request->send(200, "text/plain", String(fanController_.getDutyCycle())); });
+
+  server_.on("/fan", HTTP_PUT, [this](AsyncWebServerRequest *request)
+             {
     if (request->hasParam("duty", true)) {
       int duty = request->getParam("duty", true)->value().toInt();
       if (fanController_.setDutyCycle(duty)) {
@@ -133,20 +378,20 @@ void WebServerManager::registerRoutes() {
         return;
       }
     }
-    request->send(400, "text/plain", F("Invalid duty cycle"));
-  });
+    request->send(400, "text/plain", F("Invalid duty cycle")); });
 
-  server_.on("/ears", HTTP_GET, [this](AsyncWebServerRequest *request) {
+  server_.on("/ears", HTTP_GET, [this](AsyncWebServerRequest *request)
+             {
     JsonDocument doc;
     JsonObject obj = doc.to<JsonObject>();
     earController_.getEar().serialize(obj);
 
     String json;
     serializeJson(doc, json);
-    request->send(200, "application/json", json);
-  });
+    request->send(200, "application/json", json); });
 
-  server_.on("/ears", HTTP_PUT, [this](AsyncWebServerRequest *request) {
+  server_.on("/ears", HTTP_PUT, [this](AsyncWebServerRequest *request)
+             {
     bool updated = false;
 
     Ear &ear = earController_.getEar();
@@ -182,30 +427,31 @@ void WebServerManager::registerRoutes() {
       return;
     }
 
-    request->send(200, "text/plain", F("Color/brightness set."));
-  });
+    request->send(200, "text/plain", F("Color/brightness set.")); });
 
-  server_.on("/gyro", HTTP_GET, [this](AsyncWebServerRequest *request) {
+  server_.on("/gyro", HTTP_GET, [this](AsyncWebServerRequest *request)
+             {
     if (!tiltController_.isEnabled()) {
       request->send(200, "text/plain", F("Tilt is disabled"));
       return;
     }
-    request->send(200, "text/plain", tiltController_.readAcceleration());
-  });
+    request->send(200, "text/plain", tiltController_.readAcceleration()); });
 
-  server_.onNotFound([](AsyncWebServerRequest *request) {
-    request->send(404, "text/plain", "Not found");
-  });
+  server_.onNotFound([](AsyncWebServerRequest *request)
+                     { request->send(404, "text/plain", "Not found"); });
 }
 
 void WebServerManager::handleFileUpload(AsyncWebServerRequest *request,
                                         String filename, size_t index,
                                         uint8_t *data, size_t len,
-                                        bool final) {
+                                        bool final)
+{
   auto *context = static_cast<UploadContext *>(request->_tempObject);
 
-  if (index == 0) {
-    if (context != nullptr) {
+  if (index == 0)
+  {
+    if (context != nullptr)
+    {
       delete context;
       context = nullptr;
     }
@@ -214,15 +460,18 @@ void WebServerManager::handleFileUpload(AsyncWebServerRequest *request,
     request->_tempObject = context;
 
     filename.trim();
-    if (filename.isEmpty()) {
+    if (filename.isEmpty())
+    {
       context->error = true;
       context->message = F("File name is required.");
       return;
     }
 
-    for (size_t i = 0; i < filename.length(); ++i) {
+    for (size_t i = 0; i < filename.length(); ++i)
+    {
       char c = filename.charAt(i);
-      if (c == '/' || c == '\\') {
+      if (c == '/' || c == '\\')
+      {
         filename.setCharAt(i, '_');
       }
     }
@@ -230,67 +479,82 @@ void WebServerManager::handleFileUpload(AsyncWebServerRequest *request,
     context->targetPath = "/anims/" + filename;
     context->tempPath = context->targetPath + F(".tmp");
 
-    if (SPIFFS.exists(context->tempPath)) {
+    if (SPIFFS.exists(context->tempPath))
+    {
       SPIFFS.remove(context->tempPath);
     }
 
     request->_tempFile = SPIFFS.open(context->tempPath, FILE_WRITE);
-    if (!request->_tempFile) {
+    if (!request->_tempFile)
+    {
       context->error = true;
       context->message = F("Error opening temporary file for writing!");
       return;
     }
   }
 
-  if (context == nullptr) {
+  if (context == nullptr)
+  {
     return;
   }
 
-  if (context->error) {
-    if (final && request->_tempFile) {
+  if (context->error)
+  {
+    if (final && request->_tempFile)
+    {
       request->_tempFile.close();
       request->_tempFile = File();
     }
     return;
   }
 
-  if (len > 0 && request->_tempFile) {
+  if (len > 0 && request->_tempFile)
+  {
     size_t written = request->_tempFile.write(data, len);
-    if (written != len && !context->error) {
+    if (written != len && !context->error)
+    {
       context->error = true;
       context->message = F("Failed to write uploaded data.");
       request->_tempFile.close();
       request->_tempFile = File();
-      if (SPIFFS.exists(context->tempPath)) {
+      if (SPIFFS.exists(context->tempPath))
+      {
         SPIFFS.remove(context->tempPath);
       }
     }
   }
 
-  if (!final) {
+  if (!final)
+  {
     return;
   }
 
-  if (request->_tempFile) {
+  if (request->_tempFile)
+  {
     request->_tempFile.close();
     request->_tempFile = File();
   }
 
-  if (context->error) {
-    if (SPIFFS.exists(context->tempPath)) {
+  if (context->error)
+  {
+    if (SPIFFS.exists(context->tempPath))
+    {
       SPIFFS.remove(context->tempPath);
     }
     return;
   }
 
-  if (SPIFFS.exists(context->targetPath)) {
+  if (SPIFFS.exists(context->targetPath))
+  {
     SPIFFS.remove(context->targetPath);
   }
 
-  if (!SPIFFS.rename(context->tempPath, context->targetPath)) {
+  if (!SPIFFS.rename(context->tempPath, context->targetPath))
+  {
     context->error = true;
     context->message = F("Failed to save file.");
-    if (SPIFFS.exists(context->tempPath)) {
+    if (SPIFFS.exists(context->tempPath))
+    {
       SPIFFS.remove(context->tempPath);
     }
     return;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -36,10 +36,12 @@ namespace
     Ear &ear = earController.getEar();
     if (emotion->earColorMode == ColorMode::Gradient)
     {
+      Serial.println("[D] Setting ear gradient");
       ear.setGradient(emotion->earGradient);
     }
     else
     {
+      Serial.println("[D] Setting ear color");
       ear.setColor(emotion->earColor);
     }
   }
@@ -204,6 +206,7 @@ void WebServerManager::registerRoutes()
              {
     if (request->hasParam("name", true)) {
       emotionState_.setCurrentEmotion(request->getParam("name", true)->value());
+
       applyEmotionEarColor(earController_, emotionState_.getCurrentEmotionDefinition());
       request->send(200, "text/plain", F("Emotion changed."));
       return;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -4,143 +4,45 @@
 #include <FS.h>
 #include <vector>
 
-namespace {
-bool parseEmotionDefinitionJson(const String &jsonPayload,
-                                EmotionState::EmotionDefinition &emotion,
-                                String &error)
+namespace
 {
-  JsonDocument doc;
-  DeserializationError parseError = deserializeJson(doc, jsonPayload);
-  if (parseError)
+  bool parseEmotionDefinitionJson(const String &jsonPayload, EmotionDefinition &emotion, String &error)
   {
-    error = "Invalid JSON payload.";
-    return false;
-  }
-
-  JsonVariant root = doc.as<JsonVariant>();
-  if (!root.is<JsonObject>())
-  {
-    error = "Payload must be an object.";
-    return false;
-  }
-
-  emotion.name = root["name"] | "";
-  emotion.path = root["path"] | "";
-  if (emotion.name.isEmpty() || emotion.path.isEmpty())
-  {
-    error = "Emotion requires non-empty 'name' and 'path'.";
-    return false;
-  }
-
-  JsonVariant earColorJson = root["earColor"];
-  if (earColorJson.isNull() || !earColorJson.is<JsonObject>())
-  {
-    error = "Emotion requires 'earColor' object.";
-    return false;
-  }
-
-  const String type = earColorJson["type"] | "";
-  if (type == "solid")
-  {
-    const String color = earColorJson["color"] | "";
-    emotion.earColor.type = EmotionState::EarColor::Type::Solid;
-    emotion.earColor.solidColor = color;
-    if (color.length() != 7 || color.charAt(0) != '#')
+    JsonDocument doc;
+    DeserializationError parseError = deserializeJson(doc, jsonPayload);
+    if (parseError)
     {
-      error = "Solid earColor.color must be in #RRGGBB format.";
-      return false;
-    }
-  }
-  else if (type == "gradient")
-  {
-    JsonVariant gradientJson = earColorJson["gradient"];
-    if (gradientJson.isNull() || !gradientJson.is<JsonObject>())
-    {
-      error = "Gradient earColor requires gradient object.";
+      error = "Invalid JSON payload.";
       return false;
     }
 
-    const String from = gradientJson["from"] | "";
-    const String to = gradientJson["to"] | "";
-    if (from.length() != 7 || to.length() != 7 || from.charAt(0) != '#' || to.charAt(0) != '#')
+    JsonVariant root = doc.as<JsonVariant>();
+    if (!root.is<JsonObject>())
     {
-      error = "Gradient colors must be in #RRGGBB format.";
+      error = "Payload must be an object.";
       return false;
     }
 
-    emotion.earColor.type = EmotionState::EarColor::Type::Gradient;
-    emotion.earColor.gradient.fromColor = from;
-    emotion.earColor.gradient.toColor = to;
-    emotion.earColor.gradient.directionX = gradientJson["directionX"] | 1.0f;
-    emotion.earColor.gradient.directionY = gradientJson["directionY"] | 0.0f;
-    emotion.earColor.gradient.midpoint = gradientJson["midpoint"] | 0.5f;
-    if (emotion.earColor.gradient.midpoint < 0.0f || emotion.earColor.gradient.midpoint > 1.0f)
+    return emotion.deserialize(root.as<JsonObject>(), error);
+  }
+
+  void applyEmotionEarColor(EarController &earController, const EmotionDefinition *emotion)
+  {
+    if (emotion == nullptr)
     {
-      error = "Gradient midpoint must be within [0,1].";
-      return false;
+      return;
+    }
+
+    Ear &ear = earController.getEar();
+    if (emotion->earColorMode == ColorMode::Gradient)
+    {
+      ear.setGradient(emotion->earGradient);
+    }
+    else
+    {
+      ear.setColor(emotion->earColor);
     }
   }
-  else
-  {
-    error = "earColor.type must be either 'solid' or 'gradient'.";
-    return false;
-  }
-
-  return true;
-}
-
-void serializeEmotionDefinition(JsonArray array, const EmotionState::EmotionDefinition &emotion)
-{
-  JsonObject emotionObject = array.add<JsonObject>();
-  emotionObject["name"] = emotion.name;
-  emotionObject["path"] = emotion.path;
-
-  JsonObject earColor = emotionObject["earColor"].to<JsonObject>();
-  if (emotion.earColor.type == EmotionState::EarColor::Type::Gradient)
-  {
-    earColor["type"] = "gradient";
-    JsonObject gradient = earColor["gradient"].to<JsonObject>();
-    gradient["from"] = emotion.earColor.gradient.fromColor;
-    gradient["to"] = emotion.earColor.gradient.toColor;
-    gradient["directionX"] = emotion.earColor.gradient.directionX;
-    gradient["directionY"] = emotion.earColor.gradient.directionY;
-    gradient["midpoint"] = emotion.earColor.gradient.midpoint;
-  }
-  else
-  {
-    earColor["type"] = "solid";
-    earColor["color"] = emotion.earColor.solidColor;
-  }
-}
-
-void applyEmotionEarColor(EarController &earController,
-                          const EmotionState::EmotionDefinition *emotion)
-{
-  if (emotion == nullptr)
-  {
-    return;
-  }
-
-  Ear &ear = earController.getEar();
-  if (emotion->earColor.type == EmotionState::EarColor::Type::Gradient)
-  {
-    if (!ear.setGradientFromHex(
-            emotion->earColor.gradient.fromColor,
-            emotion->earColor.gradient.toColor,
-            emotion->earColor.gradient.directionX,
-            emotion->earColor.gradient.directionY,
-            emotion->earColor.gradient.midpoint))
-    {
-      Serial.println(F("[E] Could not apply gradient ear color from emotion."));
-    }
-    return;
-  }
-
-  if (!ear.setColorFromHex(emotion->earColor.solidColor))
-  {
-    Serial.println(F("[E] Could not apply solid ear color from emotion."));
-  }
-}
 } // namespace
 
 WebServerManager::WebServerManager(
@@ -237,15 +139,19 @@ void WebServerManager::registerRoutes()
 
   server_.on("/files", HTTP_GET, [this](AsyncWebServerRequest *request)
              {
+              auto emotionFiles = animationManager_.getEmotions();
+
     JsonDocument doc;
     JsonArray array = doc.to<JsonArray>();
-    const auto &emotions = emotionState_.getEmotionDefinitions();
-    for (const auto &emotion : emotions) {
-      serializeEmotionDefinition(array, emotion);
-    }
 
+    for (const auto &file : emotionFiles) {
+      JsonObject fileObject = array.add<JsonObject>();
+      file.serialize(fileObject);
+    }
+    
     String json;
-    serializeJson(array, json);
+    serializeJson(doc, json);
+
     request->send(200, "application/json", json); });
 
   server_.on("/emotions", HTTP_GET, [this](AsyncWebServerRequest *request)
@@ -253,7 +159,8 @@ void WebServerManager::registerRoutes()
     JsonDocument doc;
     JsonArray array = doc.to<JsonArray>();
     for (const auto &emotion : emotionState_.getEmotionDefinitions()) {
-      serializeEmotionDefinition(array, emotion);
+      JsonObject emotionObject = array.add<JsonObject>();
+      emotion.serialize(emotionObject);
     }
 
     String json;
@@ -265,26 +172,7 @@ void WebServerManager::registerRoutes()
     JsonDocument doc;
     JsonObject object = doc.to<JsonObject>();
     const auto *emotion = emotionState_.getCurrentEmotionDefinition();
-
-    object["path"] = emotionState_.getCurrentEmotion();
-    if (emotion != nullptr) {
-      object["name"] = emotion->name;
-      JsonObject earColor = object["earColor"].to<JsonObject>();
-      if (emotion->earColor.type == EmotionState::EarColor::Type::Gradient) {
-        earColor["type"] = "gradient";
-        JsonObject gradient = earColor["gradient"].to<JsonObject>();
-        gradient["from"] = emotion->earColor.gradient.fromColor;
-        gradient["to"] = emotion->earColor.gradient.toColor;
-        gradient["directionX"] = emotion->earColor.gradient.directionX;
-        gradient["directionY"] = emotion->earColor.gradient.directionY;
-        gradient["midpoint"] = emotion->earColor.gradient.midpoint;
-      } else {
-        earColor["type"] = "solid";
-        earColor["color"] = emotion->earColor.solidColor;
-      }
-    } else {
-      object["name"] = emotionState_.getDisplayEmotion();
-    }
+    emotion->serialize(object);
 
     String json;
     serializeJson(doc, json);
@@ -297,13 +185,14 @@ void WebServerManager::registerRoutes()
       return;
     }
 
-    EmotionState::EmotionDefinition emotion;
+    EmotionDefinition emotion;
+
     String error;
     if (!parseEmotionDefinitionJson(request->getParam("plain", true)->value(), emotion, error)) {
       request->send(400, "text/plain", error);
       return;
     }
-
+    
     if (!emotionState_.upsertEmotionDefinition(emotion, false)) {
       request->send(409, "text/plain", F("Emotion already exists."));
       return;
@@ -325,7 +214,7 @@ void WebServerManager::registerRoutes()
       return;
     }
 
-    EmotionState::EmotionDefinition emotion;
+    EmotionDefinition emotion;
     String error;
     if (!parseEmotionDefinitionJson(request->getParam("plain", true)->value(), emotion, error)) {
       request->send(400, "text/plain", error);
@@ -407,10 +296,11 @@ void WebServerManager::registerRoutes()
 
     if (request->hasParam("brightnessPercent", true)) {
       const float percent = request->getParam("brightnessPercent", true)->value().toFloat();
-      if (!ear.setBrightnessPercentChecked(percent)) {
-        request->send(400, "text/plain", F("Could not set brightness use 0-100 percent."));
-        return;
+      if (percent >= 100 || percent < 0) {
+         request->send(400, "text/plain", F("Could not set brightness use 0-100 percent."));
+         return;
       }
+      ear.setBrightnessPercent(percent);
       updated = true;
     } else if (request->hasParam("brightness", true)) {
       int brightness = request->getParam("brightness", true)->value().toInt();

--- a/test/http-files/Emotions.http
+++ b/test/http-files/Emotions.http
@@ -1,0 +1,25 @@
+### Get All Emotions
+
+GET http://192.168.4.1/emotions
+
+### Get current emotion
+
+GET http://192.168.4.1/emotion
+
+### Update existing emotion
+
+PUT http://192.168.4.1/emotion
+Content-Type: application/json
+
+{
+    "date": "2023-05-10",
+    "temperatureC": 30,
+    "summary": "Warm"
+}
+
+### Change current emotion
+
+PUT http://192.168.4.1/emotion
+Content-Type: application/x-www-form-urlencoded
+
+name=Sad

--- a/test/http-files/Emotions.http
+++ b/test/http-files/Emotions.http
@@ -22,4 +22,4 @@ Content-Type: application/json
 PUT http://192.168.4.1/emotion
 Content-Type: application/x-www-form-urlencoded
 
-name=Sad
+name=Neutral

--- a/test/http-files/Emotions.http
+++ b/test/http-files/Emotions.http
@@ -22,4 +22,4 @@ Content-Type: application/json
 PUT http://192.168.4.1/emotion
 Content-Type: application/x-www-form-urlencoded
 
-name=Neutral
+name=Blush

--- a/test/http-files/Files.http
+++ b/test/http-files/Files.http
@@ -1,0 +1,3 @@
+### Get all files
+
+GET http://192.168.4.1/files


### PR DESCRIPTION
### Motivation
- Allow emotions to be richer objects (name, path) with an associated ear color that can be either a solid color or a gradient so the device can change ear LED visuals together with animations. 
- Provide HTTP CRUD endpoints so emotions can be created, updated and removed via JSON and so the current emotion can be selected programmatically.

### Description
- Introduce `EmotionState::EmotionDefinition`, `EarColor`, and `EarGradient` and in-memory helpers to query, seed, upsert and remove emotions; seed default emotions on startup (`src/EmotionState.hpp`, `src/EmotionState.cpp`).
- Extend ear handling with gradient support: add `Gradient` struct and `ColorMode` enum, gradient parsing/setters, serialization and per-LED gradient rendering in `EarController` (`src/EarController.hpp`, `src/EarController.cpp`).
- Add JSON parsing/serialization helpers and wire new web API endpoints in `WebServerManager` for emotion management: `GET /emotions`, `GET /emotion` (returns JSON with name/path and earColor), `POST /emotion` (create), `PUT /emotion` (update or select via `name` param), and `DELETE /emotion?name=...`; also apply configured earColor when the current emotion changes (`src/WebServerManager.cpp`).
- Update the web UI to consume the new JSON `GET /emotion` response and to track/highlight the current emotion by path (`data/index.html`).
- Notes: emotion definitions are stored in-memory and seeded at startup; ear color validation expects `#RRGGBB` for solid colors and similar for gradient endpoints.

### Testing
- Attempted a full firmware build with `platformio run`, but it failed because `platformio` is not installed in the environment (automated build could not be executed). (failed)
- Performed a local syntax-only compile check with `g++ -fsyntax-only -std=c++17 -I src -x c++ src/EmotionState.cpp src/EarController.cpp src/WebServerManager.cpp`, but it failed due to missing embedded/Arduino headers (`Arduino.h`, `ESPAsyncWebServer.h`, etc.) in this host environment (so no isolated compile success). (failed)
- No other automated unit tests were available in-repo; runtime verification should be done on the target device (ESP32) with PlatformIO to validate LED gradient rendering and the HTTP endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b162dd4964832dbc7fa2e7b64294a1)