### PR TITLE
Remove ear color mutation from /ears PUT and web UI

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -617,8 +617,6 @@
         <button id="earRefresh" class="icon-button" type="button" aria-label="Refresh ears" title="Refresh">↻</button>
       </div>
       <div class="row">
-        <label for="earColor">Color</label>
-        <input id="earColor" type="color" value="#ffffff">
         <label for="earBrightness">Brightness</label>
         <input id="earBrightness" type="range" min="0" max="100" value="50">
         <span id="earBrightnessValue" class="value">50%</span>
@@ -718,7 +716,6 @@
       var fanSlider = $("fanSlider");
       var fanSliderValue = $("fanSliderValue");
       var fanStatus = $("fanStatus");
-      var earColor = $("earColor");
       var earColorText = $("earColorText");
       var earBrightness = $("earBrightness");
       var earBrightnessText = $("earBrightnessText");
@@ -1197,9 +1194,6 @@
           var color = typeof payload.color === "string" ? payload.color.toLowerCase() : "#ffffff";
           var brightnessPercent = Number(payload.brightnessPercent);
           setText(earColorText, color);
-          if (/^#[0-9a-f]{6}$/i.test(color)) {
-            earColor.value = color;
-          }
           if (isFinite(brightnessPercent)) {
             var rounded = Math.round(brightnessPercent);
             setText(earBrightnessText, rounded + "%");
@@ -1217,7 +1211,6 @@
 
       function applyEars() {
         var body = new URLSearchParams({
-          color: earColor.value,
           brightnessPercent: earBrightness.value
         });
         fetchText("/ears", {

--- a/src/WebEndpoints/Ears/EarsEndpoint.cpp
+++ b/src/WebEndpoints/Ears/EarsEndpoint.cpp
@@ -31,8 +31,7 @@ void EarsEndpoint::handlePut(AsyncWebServerRequest *request)
   bool updated = false;
   Ear &ear = earController_.getEar();
 
-  if (!updateColor(request, ear, updated) ||
-      !updateBrightness(request, ear, updated))
+  if (!updateBrightness(request, ear, updated))
   {
     return;
   }
@@ -43,27 +42,7 @@ void EarsEndpoint::handlePut(AsyncWebServerRequest *request)
     return;
   }
 
-  request->send(200, "text/plain", F("Color/brightness set."));
-}
-
-bool EarsEndpoint::updateColor(AsyncWebServerRequest *request, Ear &ear,
-                               bool &updated)
-{
-  if (!request->hasParam("color", true))
-  {
-    return true;
-  }
-
-  const String color = request->getParam("color", true)->value();
-  if (!ear.setColorFromHex(color))
-  {
-    request->send(400, "text/plain",
-                  F("Could not set color use #FFFFFF format."));
-    return false;
-  }
-
-  updated = true;
-  return true;
+  request->send(200, "text/plain", F("Brightness set."));
 }
 
 bool EarsEndpoint::updateBrightness(AsyncWebServerRequest *request, Ear &ear,

--- a/src/WebEndpoints/Ears/EarsEndpoint.hpp
+++ b/src/WebEndpoints/Ears/EarsEndpoint.hpp
@@ -14,7 +14,6 @@ public:
 private:
   void handleGet(AsyncWebServerRequest *request);
   void handlePut(AsyncWebServerRequest *request);
-  bool updateColor(AsyncWebServerRequest *request, Ear &ear, bool &updated);
   bool updateBrightness(AsyncWebServerRequest *request, Ear &ear,
                         bool &updated);
 

--- a/test/http-files/Ears.http
+++ b/test/http-files/Ears.http
@@ -3,11 +3,11 @@
 ### Read the current ear LED state
 GET {{baseUrl}}/ears
 
-### Set ear color and brightness percentage
+### Set ear brightness percentage
 PUT {{baseUrl}}/ears
 Content-Type: application/x-www-form-urlencoded
 
-color=%23FF8800&brightnessPercent=35
+brightnessPercent=35
 
 ### Set ear brightness using the raw 0-255 scale
 PUT {{baseUrl}}/ears


### PR DESCRIPTION
### Motivation
- Prevent client-side and endpoint-based modification of ear color while preserving read-only visibility of the current color via `GET /ears`.
- Simplify the `/ears` `PUT` endpoint to only accept brightness changes and avoid exposing color-setting functionality from the web UI.

### Description
- Removed the ear color input and related client-side usage from `data/index.html` so the UI no longer allows changing ear color but still displays the current color from `GET /ears`.
- Stopped sending the `color` field in the UI `PUT /ears` payload by updating the `applyEars` logic in `data/index.html` to only send `brightnessPercent`.
- Removed the server-side color handling by deleting `updateColor` and its header declaration and no longer invoking it in `src/WebEndpoints/Ears/EarsEndpoint.cpp`, and adjusted the success response to `"Brightness set."`.
- Updated the HTTP example in `test/http-files/Ears.http` to reflect a brightness-only `PUT /ears` request.

### Testing
- Attempted to run a full build with `pio run`, but it failed in this environment with `/bin/bash: line 1: pio: command not found`, so no build/test artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26c32a860832d80b65524cca4b025)