### PR TITLE
Remove ear color UI from Ears control panel

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -613,7 +613,7 @@
     <section>
       <h2>Ears</h2>
       <div class="display-row">
-        <div class="value-display">Color: <span id="earColorText" class="value">--</span> | Brightness: <span id="earBrightnessText" class="value">--%</span></div>
+        <div class="value-display">Brightness: <span id="earBrightnessText" class="value">--%</span></div>
         <button id="earRefresh" class="icon-button" type="button" aria-label="Refresh ears" title="Refresh">↻</button>
       </div>
       <div class="row">
@@ -716,7 +716,6 @@
       var fanSlider = $("fanSlider");
       var fanSliderValue = $("fanSliderValue");
       var fanStatus = $("fanStatus");
-      var earColorText = $("earColorText");
       var earBrightness = $("earBrightness");
       var earBrightnessText = $("earBrightnessText");
       var earBrightnessValue = $("earBrightnessValue");
@@ -1191,9 +1190,7 @@
       function refreshEars() {
         fetchJson("/ears").then(function (data) {
           var payload = (data && typeof data === "object" && !Array.isArray(data)) ? data : {};
-          var color = typeof payload.color === "string" ? payload.color.toLowerCase() : "#ffffff";
           var brightnessPercent = Number(payload.brightnessPercent);
-          setText(earColorText, color);
           if (isFinite(brightnessPercent)) {
             var rounded = Math.round(brightnessPercent);
             setText(earBrightnessText, rounded + "%");


### PR DESCRIPTION
### Motivation
- Simplify the Ears control panel by removing color display/handling so the UI only exposes brightness controls.

### Description
- Removed the color readout from the Ears section in `data/index.html` and deleted the now-unused `earColorText` DOM lookup in the frontend script, and stopped setting the color in `refreshEars()`.

### Testing
- Ran `git diff --check` and a targeted search with `rg -n 'earColorText' data/index.html` to verify the color readout reference was removed, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba330ea54832db2687874ced8621b)