### PR TITLE
Refactor file model and FileEndpoint; add FileManager file operations and robust upload handling

### DIFF
--- a/src/BLEController.cpp
+++ b/src/BLEController.cpp
@@ -9,7 +9,7 @@ BLEController::CharacteristicCallbacks::CharacteristicCallbacks(FileManager &fil
 
 void BLEController::CharacteristicCallbacks::onWrite(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo &connInfo)
 {
-    auto emotions = fileManager_.getEmotions();
+    auto emotions = fileManager_.getAnimationFiles();
     auto emotionCount = emotions.size();
 
     String characteristicValue = String(pCharacteristic->getValue().c_str());
@@ -85,7 +85,7 @@ BLEController::BLEController(FileManager &fileManager, EmotionState &emotionStat
 
 bool BLEController::begin()
 {
-    auto emotions = fileManager_.getEmotions();
+    auto emotions = fileManager_.getAnimationFiles();
     std::string stdStr("Proto", 5);
     BLEDevice::init(stdStr);
     NimBLEDevice::setPower(ESP_PWR_LVL_P9);

--- a/src/FileManager.cpp
+++ b/src/FileManager.cpp
@@ -13,9 +13,14 @@ bool FileManager::begin(bool formatOnFail)
   return true;
 }
 
-std::vector<AnimationFile> FileManager::getEmotions() const
+std::vector<Model::File> FileManager::getAnimationFiles() const
 {
-  std::vector<AnimationFile> animations;
+  return getFiles();
+}
+
+std::vector<Model::File> FileManager::getFiles(const String &filter) const
+{
+  std::vector<Model::File> animations;
 
   File animationsDir = SPIFFS.open("/anims");
   if (!animationsDir || !animationsDir.isDirectory())
@@ -24,14 +29,17 @@ std::vector<AnimationFile> FileManager::getEmotions() const
     return animations;
   }
 
+  const String normalizedFilter = String(filter);
   File file = animationsDir.openNextFile();
   while (file)
   {
-    AnimationFile info;
+    Model::File info;
     info.path = file.path();
     info.name = FileHelper::GetNameOnly(info.path);
 
-    if (info.path.endsWith(".gif"))
+    if (info.path.endsWith(".gif") &&
+        (normalizedFilter.isEmpty() || info.name.indexOf(normalizedFilter) >= 0 ||
+         info.path.indexOf(normalizedFilter) >= 0))
     {
       animations.push_back(std::move(info));
     }
@@ -46,11 +54,16 @@ std::vector<AnimationFile> FileManager::getEmotions() const
 
 void FileManager::printEmotions() const
 {
-  const auto animations = getEmotions();
+  const auto animations = getAnimationFiles();
   for (const auto &anim : animations)
   {
     Serial.printf("Animation: %s, Path: %s\n", anim.name.c_str(), anim.path.c_str());
   }
+}
+
+bool FileManager::exists(const String &path) const
+{
+  return SPIFFS.exists(path);
 }
 
 bool FileManager::readFile(const String &path, String &content) const
@@ -64,4 +77,29 @@ bool FileManager::readFile(const String &path, String &content) const
   content = file.readString();
   file.close();
   return true;
+}
+
+bool FileManager::writeFile(const String &path, const uint8_t *data, size_t len,
+                            bool append) const
+{
+  const char *mode = append ? FILE_APPEND : FILE_WRITE;
+  File file = SPIFFS.open(path, mode);
+  if (!file)
+  {
+    return false;
+  }
+
+  const size_t written = file.write(data, len);
+  file.close();
+  return written == len;
+}
+
+bool FileManager::removeFile(const String &path) const
+{
+  return SPIFFS.remove(path);
+}
+
+bool FileManager::renameFile(const String &from, const String &to) const
+{
+  return SPIFFS.rename(from, to);
 }

--- a/src/FileManager.hpp
+++ b/src/FileManager.hpp
@@ -11,9 +11,16 @@
 class FileManager {
 public:
   bool begin(bool formatOnFail = true);
-  std::vector<AnimationFile> getEmotions() const;
+  std::vector<Model::File> getAnimationFiles() const;
+  std::vector<Model::File> getFiles(const String &filter = "") const;
   void printEmotions() const;
+
+  bool exists(const String &path) const;
   bool readFile(const String &path, String &content) const;
+  bool writeFile(const String &path, const uint8_t *data, size_t len,
+                 bool append = false) const;
+  bool removeFile(const String &path) const;
+  bool renameFile(const String &from, const String &to) const;
 };
 
 #endif // FILE_MANAGER_HPP

--- a/src/Model/AnimationFile.cpp
+++ b/src/Model/AnimationFile.cpp
@@ -1,31 +1,31 @@
 #include "AnimationFile.hpp"
 
-void AnimationFile::serialize(JsonVariant json) const
+void Model::File::serialize(JsonVariant json) const
 {
-    if (json.isNull())
-    {
-        return;
-    }
+  if (json.isNull())
+  {
+    return;
+  }
 
-    json["name"] = name;
-    json["path"] = path;
+  json["name"] = name;
+  json["path"] = path;
 }
 
-bool AnimationFile::deserialize(const JsonObject &object, String &error)
+bool Model::File::deserialize(const JsonObject &object, String &error)
 {
-    if (!object["name"].is<String>())
-    {
-        error = F("AnimationFile 'name' is required and must be a string.");
-        return false;
-    }
-    name = object["name"].as<String>();
+  if (!object["name"].is<String>())
+  {
+    error = F("File 'name' is required and must be a string.");
+    return false;
+  }
+  name = object["name"].as<String>();
 
-    if (!object["path"].is<String>())
-    {
-        error = F("AnimationFile 'path' is required and must be a string.");
-        return false;
-    }
-    path = object["path"].as<String>();
+  if (!object["path"].is<String>())
+  {
+    error = F("File 'path' is required and must be a string.");
+    return false;
+  }
+  path = object["path"].as<String>();
 
-    return true;
+  return true;
 }

--- a/src/Model/AnimationFile.hpp
+++ b/src/Model/AnimationFile.hpp
@@ -1,16 +1,19 @@
-
 #ifndef ANIMATION_FILE_HPP
 #define ANIMATION_FILE_HPP
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
-  
-struct AnimationFile {
-    String name;
-    String path;
 
-    void serialize(JsonVariant json) const;
-    bool deserialize(const JsonObject &object, String &error);
+namespace Model {
+
+struct File {
+  String name;
+  String path;
+
+  void serialize(JsonVariant json) const;
+  bool deserialize(const JsonObject &object, String &error);
 };
 
-#endif //ANIMATION_FILE_HPP
+} // namespace Model
+
+#endif // ANIMATION_FILE_HPP

--- a/src/WebEndpoints/Files/FileEndpoint.cpp
+++ b/src/WebEndpoints/Files/FileEndpoint.cpp
@@ -1,9 +1,19 @@
 #include "WebEndpoints/Files/FileEndpoint.hpp"
 
+#include <SPIFFS.h>
+
 #include <FS.h>
+
+FileEndpoint::FileEndpoint(FileManager &fileManager)
+    : fileManager_(fileManager)
+{
+}
 
 void FileEndpoint::registerEndpoint(AsyncWebServer &server)
 {
+  server.on("/file", HTTP_GET, [this](AsyncWebServerRequest *request)
+            { handleGet(request); });
+
   server.on(
       "/file", HTTP_POST,
       [this](AsyncWebServerRequest *request)
@@ -13,12 +23,42 @@ void FileEndpoint::registerEndpoint(AsyncWebServer &server)
       [this](AsyncWebServerRequest *request, String filename, size_t index,
              uint8_t *data, size_t len, bool final)
       {
-        Serial.println(F("[I] File upload callback called"));
+        handleUploadChunk(request, filename, index, data, len, final);
+      });
+
+  server.on(
+      "/file", HTTP_PUT,
+      [this](AsyncWebServerRequest *request)
+      {
+        handleUploadComplete(request);
+      },
+      [this](AsyncWebServerRequest *request, String filename, size_t index,
+             uint8_t *data, size_t len, bool final)
+      {
         handleUploadChunk(request, filename, index, data, len, final);
       });
 
   server.on("/file", HTTP_DELETE, [this](AsyncWebServerRequest *request)
             { handleDelete(request); });
+}
+
+void FileEndpoint::handleGet(AsyncWebServerRequest *request)
+{
+  String filePath;
+  if (!resolveAndValidateFilePath(request, filePath))
+  {
+    request->send(400, "text/plain",
+                  F("Missing or invalid 'file' parameter (use /anims/* path)."));
+    return;
+  }
+
+  if (!fileManager_.exists(filePath))
+  {
+    request->send(404, "text/plain", F("File not found."));
+    return;
+  }
+
+  request->send(SPIFFS, filePath, String(), true);
 }
 
 void FileEndpoint::handleUploadComplete(AsyncWebServerRequest *request)
@@ -30,20 +70,14 @@ void FileEndpoint::handleUploadComplete(AsyncWebServerRequest *request)
     return;
   }
 
+  const int statusCode = context->error ? context->statusCode : 200;
   String message = context->message;
   if (!message.length())
   {
     message = F("File was saved.");
   }
 
-  if (context->error)
-  {
-    request->send(400, "text/plain", message);
-  }
-  else
-  {
-    request->send(200, "text/plain", message);
-  }
+  request->send(statusCode, "text/plain", message);
 
   delete context;
   request->_tempObject = nullptr;
@@ -61,55 +95,44 @@ void FileEndpoint::handleUploadChunk(AsyncWebServerRequest *request,
     return;
   }
 
-  if (context->error)
+  if (!context->error)
   {
-    if (final)
-    {
-      cleanupUploadFile(request);
-    }
-    return;
+    writeUploadChunk(request, index, len, data);
   }
 
-  writeUploadChunk(request, len, data);
-
-  if (!final)
+  if (final)
   {
-    return;
+    finalizeUpload(request);
   }
-
-  finalizeUpload(request);
 }
 
 void FileEndpoint::handleDelete(AsyncWebServerRequest *request)
 {
-  if (!request->hasParam("file"))
-  {
-    request->send(400, "text/plain", F("Parameter 'file' not present!"));
-    return;
-  }
-
-  const String filePath = request->getParam("file")->value();
-  Serial.println("[I] Deleting " + filePath);
-
-  if (!SPIFFS.exists(filePath))
-  {
-    request->send(400, "text/plain", F("File does not exist!"));
-    return;
-  }
-
-  if (!filePath.startsWith("/anims/"))
+  String filePath;
+  if (!resolveAndValidateFilePath(request, filePath))
   {
     request->send(400, "text/plain",
-                  F("Cannot delete the file, file is not an animation!"));
+                  F("Missing or invalid 'file' parameter (use /anims/* path)."));
     return;
   }
 
-  SPIFFS.remove(filePath);
+  if (!fileManager_.exists(filePath))
+  {
+    request->send(404, "text/plain", F("File not found."));
+    return;
+  }
+
+  if (!fileManager_.removeFile(filePath))
+  {
+    request->send(500, "text/plain", F("Failed to delete file."));
+    return;
+  }
+
   request->send(200, "text/plain", F("File was deleted."));
 }
 
 void FileEndpoint::initializeUploadContext(AsyncWebServerRequest *request,
-                                           String &filename, size_t index)
+                                           String filename, size_t index)
 {
   if (index != 0)
   {
@@ -126,52 +149,77 @@ void FileEndpoint::initializeUploadContext(AsyncWebServerRequest *request,
   context = new UploadContext();
   request->_tempObject = context;
 
+  if (request->hasParam("file", true))
+  {
+    filename = request->getParam("file", true)->value();
+  }
+  else if (request->hasParam("file"))
+  {
+    filename = request->getParam("file")->value();
+  }
+
   filename.trim();
   if (filename.isEmpty())
   {
     context->error = true;
+    context->statusCode = 400;
     context->message = F("File name is required.");
     return;
   }
 
-  sanitizeFilename(filename);
-  context->targetPath = "/anims/" + filename;
-  context->tempPath = context->targetPath + F(".tmp");
-
-  if (SPIFFS.exists(context->tempPath))
-  {
-    SPIFFS.remove(context->tempPath);
-  }
-
-  request->_tempFile = SPIFFS.open(context->tempPath, FILE_WRITE);
-  if (!request->_tempFile)
+  if (!normalizeFilePath(filename, context->targetPath))
   {
     context->error = true;
-    context->message = F("Error opening temporary file for writing!");
+    context->statusCode = 400;
+    context->message = F("Invalid file path. Use /anims/* path.");
+    return;
+  }
+
+  const bool isPut = request->method() == HTTP_PUT;
+  context->overwrite = isPut;
+
+  const bool exists = fileManager_.exists(context->targetPath);
+  if (isPut && !exists)
+  {
+    context->error = true;
+    context->statusCode = 404;
+    context->message = F("Cannot update missing file.");
+    return;
+  }
+
+  if (!isPut && exists)
+  {
+    context->error = true;
+    context->statusCode = 409;
+    context->message = F("File already exists.");
+    return;
+  }
+
+  context->tempPath = context->targetPath + F(".tmp");
+  if (fileManager_.exists(context->tempPath) &&
+      !fileManager_.removeFile(context->tempPath))
+  {
+    context->error = true;
+    context->statusCode = 500;
+    context->message = F("Failed to prepare temporary file.");
   }
 }
 
-void FileEndpoint::writeUploadChunk(AsyncWebServerRequest *request, size_t len,
-                                    uint8_t *data)
+void FileEndpoint::writeUploadChunk(AsyncWebServerRequest *request, size_t index,
+                                    size_t len, uint8_t *data)
 {
   auto *context = getUploadContext(request);
-  if (context == nullptr || len == 0 || !request->_tempFile)
+  if (context == nullptr || len == 0)
   {
     return;
   }
 
-  const size_t written = request->_tempFile.write(data, len);
-  if (written == len || context->error)
+  const bool append = index > 0;
+  if (!fileManager_.writeFile(context->tempPath, data, len, append))
   {
-    return;
-  }
-
-  context->error = true;
-  context->message = F("Failed to write uploaded data.");
-  cleanupUploadFile(request);
-  if (SPIFFS.exists(context->tempPath))
-  {
-    SPIFFS.remove(context->tempPath);
+    context->error = true;
+    context->statusCode = 500;
+    context->message = F("Failed to write uploaded data.");
   }
 }
 
@@ -183,59 +231,87 @@ void FileEndpoint::finalizeUpload(AsyncWebServerRequest *request)
     return;
   }
 
-  cleanupUploadFile(request);
-
   if (context->error)
   {
-    if (SPIFFS.exists(context->tempPath))
+    if (fileManager_.exists(context->tempPath))
     {
-      SPIFFS.remove(context->tempPath);
+      fileManager_.removeFile(context->tempPath);
     }
     return;
   }
 
-  if (SPIFFS.exists(context->targetPath))
-  {
-    SPIFFS.remove(context->targetPath);
-  }
-
-  if (!SPIFFS.rename(context->tempPath, context->targetPath))
+  if (context->overwrite && fileManager_.exists(context->targetPath) &&
+      !fileManager_.removeFile(context->targetPath))
   {
     context->error = true;
-    context->message = F("Failed to save file.");
-    if (SPIFFS.exists(context->tempPath))
-    {
-      SPIFFS.remove(context->tempPath);
-    }
+    context->statusCode = 500;
+    context->message = F("Failed to replace existing file.");
+    fileManager_.removeFile(context->tempPath);
     return;
   }
 
-  context->message = F("File was saved.");
+  if (!fileManager_.renameFile(context->tempPath, context->targetPath))
+  {
+    context->error = true;
+    context->statusCode = 500;
+    context->message = F("Failed to save file.");
+    fileManager_.removeFile(context->tempPath);
+    return;
+  }
+
+  context->message = context->overwrite ? F("File was updated.") : F("File was created.");
+}
+
+bool FileEndpoint::resolveAndValidateFilePath(AsyncWebServerRequest *request,
+                                              String &resolvedPath) const
+{
+  if (request->hasParam("file"))
+  {
+    return normalizeFilePath(request->getParam("file")->value(), resolvedPath);
+  }
+
+  if (request->hasParam("path"))
+  {
+    return normalizeFilePath(request->getParam("path")->value(), resolvedPath);
+  }
+
+  return false;
+}
+
+bool FileEndpoint::normalizeFilePath(const String &input,
+                                     String &normalizedPath) const
+{
+  normalizedPath = input;
+  normalizedPath.trim();
+
+  if (normalizedPath.isEmpty())
+  {
+    return false;
+  }
+
+  sanitizeFilename(normalizedPath);
+
+  if (normalizedPath.startsWith("/anims/"))
+  {
+    return normalizedPath.indexOf("..") < 0;
+  }
+
+  if (normalizedPath.startsWith("/"))
+  {
+    return false;
+  }
+
+  normalizedPath = "/anims/" + normalizedPath;
+  return normalizedPath.indexOf("..") < 0;
+}
+
+void FileEndpoint::sanitizeFilename(String &filename) const
+{
+  filename.replace('\\', '/');
 }
 
 FileEndpoint::UploadContext *FileEndpoint::getUploadContext(
     AsyncWebServerRequest *request) const
 {
   return static_cast<UploadContext *>(request->_tempObject);
-}
-
-void FileEndpoint::cleanupUploadFile(AsyncWebServerRequest *request) const
-{
-  if (request->_tempFile)
-  {
-    request->_tempFile.close();
-    request->_tempFile = File();
-  }
-}
-
-void FileEndpoint::sanitizeFilename(String &filename) const
-{
-  for (size_t i = 0; i < filename.length(); ++i)
-  {
-    const char currentChar = filename.charAt(i);
-    if (currentChar == '/' || currentChar == '\\')
-    {
-      filename.setCharAt(i, '_');
-    }
-  }
 }

--- a/src/WebEndpoints/Files/FileEndpoint.hpp
+++ b/src/WebEndpoints/Files/FileEndpoint.hpp
@@ -2,35 +2,47 @@
 #define WEB_ENDPOINTS_FILES_FILE_ENDPOINT_HPP
 
 #include <ESPAsyncWebServer.h>
-#include <SPIFFS.h>
 
 #include <Arduino.h>
 
+#include "FileManager.hpp"
+
 class FileEndpoint {
 public:
+  explicit FileEndpoint(FileManager &fileManager);
+
   void registerEndpoint(AsyncWebServer &server);
 
 private:
   struct UploadContext {
     String targetPath;
     String tempPath;
+    bool overwrite = false;
     bool error = false;
+    int statusCode = 500;
     String message;
   };
 
+  void handleGet(AsyncWebServerRequest *request);
   void handleUploadComplete(AsyncWebServerRequest *request);
   void handleUploadChunk(AsyncWebServerRequest *request, String filename,
                          size_t index, uint8_t *data, size_t len,
                          bool final);
   void handleDelete(AsyncWebServerRequest *request);
-  void initializeUploadContext(AsyncWebServerRequest *request, String &filename,
+
+  void initializeUploadContext(AsyncWebServerRequest *request, String filename,
                                size_t index);
-  void writeUploadChunk(AsyncWebServerRequest *request, size_t len,
+  void writeUploadChunk(AsyncWebServerRequest *request, size_t index, size_t len,
                         uint8_t *data);
   void finalizeUpload(AsyncWebServerRequest *request);
-  UploadContext *getUploadContext(AsyncWebServerRequest *request) const;
-  void cleanupUploadFile(AsyncWebServerRequest *request) const;
+
+  bool resolveAndValidateFilePath(AsyncWebServerRequest *request,
+                                  String &resolvedPath) const;
+  bool normalizeFilePath(const String &input, String &normalizedPath) const;
   void sanitizeFilename(String &filename) const;
+  UploadContext *getUploadContext(AsyncWebServerRequest *request) const;
+
+  FileManager &fileManager_;
 };
 
 #endif // WEB_ENDPOINTS_FILES_FILE_ENDPOINT_HPP

--- a/src/WebEndpoints/Files/FilesEndpoint.cpp
+++ b/src/WebEndpoints/Files/FilesEndpoint.cpp
@@ -15,7 +15,10 @@ void FilesEndpoint::registerEndpoint(AsyncWebServer &server)
 
 void FilesEndpoint::handleGet(AsyncWebServerRequest *request)
 {
-  const auto emotionFiles = fileManager_.getEmotions();
+  const String filter = request->hasParam("filter")
+                            ? request->getParam("filter")->value()
+                            : String();
+  const auto emotionFiles = fileManager_.getFiles(filter);
 
   JsonDocument document;
   JsonArray files = document.to<JsonArray>();

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -9,7 +9,7 @@ WebServerManager::WebServerManager(
     std::function<void()> onSettingsChanged)
     : server_(80),
       staticContentEndpoint_(),
-      fileEndpoint_(),
+      fileEndpoint_(fileManager),
       filesEndpoint_(fileManager),
       emotionsEndpoint_(emotionState),
       emotionEndpoint_(emotionState, earController, onSettingsChanged),


### PR DESCRIPTION
### Motivation
- Generalize from "emotions" to a reusable file model and provide robust server-side file operations for animation assets.
- Replace ad-hoc SPIFFS usage across endpoints with `FileManager` APIs to centralize file I/O and error handling.
- Improve the HTTP file upload/download/delete behavior to support GET, PUT (overwrite), proper status codes, path normalization, and temporary file handling.

### Description
- Introduced `Model::File` (replacing `AnimationFile`) and updated serialization/deserialization to `Model::File::serialize`/`deserialize`.
- Renamed `FileManager::getEmotions` to `FileManager::getAnimationFiles` and added `FileManager::getFiles`, `exists`, `writeFile`, `removeFile`, and `renameFile` to centralize SPIFFS operations.
- Updated `BLEController` to use `getAnimationFiles` for Bluetooth interactions.
- Reworked `FileEndpoint` to take a `FileManager&` in the constructor, add `GET /file`, support `PUT /file` for updates, validate/normalize incoming paths, use temporary `.tmp` files, set appropriate HTTP status codes, and return contextual messages on success/failure.
- Simplified upload handling into `initializeUploadContext`, `writeUploadChunk`, `finalizeUpload`, and added helpers `resolveAndValidateFilePath` and `normalizeFilePath` for safe path handling and filename sanitization.
- Updated `FilesEndpoint` to accept a `filter` query parameter and use `FileManager::getFiles(filter)` when listing files.
- Adjusted `WebServerManager` to construct `FileEndpoint` with the `FileManager` reference.

### Testing
- Project build completed successfully (`platformio run` / project compile).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcbda3864832d8f6759194ba5e4ed)