### PR TITLE
Serve files with chunked response, add heap/size safeguards

### DIFF
--- a/src/WebEndpoints/Files/FileEndpoint.cpp
+++ b/src/WebEndpoints/Files/FileEndpoint.cpp
@@ -3,6 +3,14 @@
 #include <SPIFFS.h>
 
 #include <FS.h>
+#include <memory>
+
+namespace
+{
+constexpr size_t kDownloadChunkSizeBytes = 1024;
+constexpr size_t kMaxDownloadBytes = 512 * 1024;
+constexpr uint32_t kMinDownloadFreeHeapBytes = 20 * 1024;
+}
 
 FileEndpoint::FileEndpoint(FileManager &fileManager, bool allowAllFileChanges)
     : fileManager_(fileManager), allowAllFileChanges_(allowAllFileChanges)
@@ -58,7 +66,82 @@ void FileEndpoint::handleGet(AsyncWebServerRequest *request)
     return;
   }
 
-  request->send(SPIFFS, filePath, String(), true);
+  if (ESP.getFreeHeap() < kMinDownloadFreeHeapBytes)
+  {
+    request->send(503, "text/plain", F("Insufficient heap to serve file."));
+    return;
+  }
+
+  File file = SPIFFS.open(filePath, FILE_READ);
+  if (!file)
+  {
+    request->send(500, "text/plain", F("Failed to open file."));
+    return;
+  }
+
+  const size_t fileSize = file.size();
+  if (fileSize > kMaxDownloadBytes)
+  {
+    file.close();
+    request->send(413, "text/plain", F("File too large for this endpoint."));
+    return;
+  }
+
+  struct DownloadContext
+  {
+    File file;
+    size_t remaining = 0;
+  };
+
+  auto context = std::make_shared<DownloadContext>();
+  context->file = std::move(file);
+  context->remaining = fileSize;
+
+  AsyncWebServerResponse *response = request->beginChunkedResponse(
+      "application/octet-stream",
+      [context](uint8_t *buffer, size_t maxLen, size_t /*index*/) mutable -> size_t
+      {
+        if (!context || !context->file || context->remaining == 0)
+        {
+          if (context && context->file)
+          {
+            context->file.close();
+          }
+          context.reset();
+          return 0;
+        }
+
+        size_t toRead = maxLen;
+        if (toRead > kDownloadChunkSizeBytes)
+        {
+          toRead = kDownloadChunkSizeBytes;
+        }
+
+        if (toRead > context->remaining)
+        {
+          toRead = context->remaining;
+        }
+
+        const size_t bytesRead = context->file.read(buffer, toRead);
+        if (bytesRead == 0)
+        {
+          context->file.close();
+          context.reset();
+          return 0;
+        }
+
+        context->remaining -= bytesRead;
+        if (context->remaining == 0)
+        {
+          context->file.close();
+          context.reset();
+        }
+
+        return bytesRead;
+      });
+
+  response->addHeader("Content-Disposition", "attachment");
+  request->send(response);
 }
 
 void FileEndpoint::handleUploadComplete(AsyncWebServerRequest *request)


### PR DESCRIPTION
### Motivation

- Replace the direct `SPIFFS` send with a controlled chunked streaming implementation to avoid running out of heap and to protect the device from serving very large files.

### Description

- Added constants `kDownloadChunkSizeBytes`, `kMaxDownloadBytes`, and `kMinDownloadFreeHeapBytes` and included `<memory>` for the new streaming logic.
- Check `ESP.getFreeHeap()` and return `503` when free heap is below `kMinDownloadFreeHeapBytes` to avoid OOM during downloads.
- Open files via `SPIFFS.open` and return `500` on open failure, and return `413` when file size exceeds `kMaxDownloadBytes`.
- Implement a `DownloadContext` wrapped in `std::shared_ptr` and stream file contents using `request->beginChunkedResponse`, reading in up to `kDownloadChunkSizeBytes` chunks and adding a `Content-Disposition: attachment` header.

### Testing

- Ran a full project build with `platformio run` and the build completed successfully.
- Executed an automated endpoint streaming test that downloads a small file via GET `/file` and verifies the payload integrity, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df734cef74832da12ccb7f11e57ce7)