### PR TITLE
Add capability manager and /capabilities endpoint

### DIFF
--- a/src/Capabilities/BrightnessDownCapability.cpp
+++ b/src/Capabilities/BrightnessDownCapability.cpp
@@ -1,0 +1,34 @@
+#include "Capabilities/BrightnessDownCapability.hpp"
+
+namespace
+{
+constexpr float kStepPercent = 20.0f;
+constexpr float kMinPercent = 0.0f;
+}
+
+BrightnessDownCapability::BrightnessDownCapability(
+    EarController &earController,
+    std::function<void()> onSettingsChanged)
+    : Capability(F("brightness_down")),
+      earController_(earController),
+      onSettingsChanged_(onSettingsChanged)
+{
+}
+
+bool BrightnessDownCapability::handle()
+{
+  float nextBrightness = earController_.getBrightnessPercent() - kStepPercent;
+  if (nextBrightness < kMinPercent)
+  {
+    nextBrightness = kMinPercent;
+  }
+
+  earController_.setBrightnessPercent(nextBrightness);
+
+  if (onSettingsChanged_)
+  {
+    onSettingsChanged_();
+  }
+
+  return true;
+}

--- a/src/Capabilities/BrightnessDownCapability.hpp
+++ b/src/Capabilities/BrightnessDownCapability.hpp
@@ -1,0 +1,22 @@
+#ifndef BRIGHTNESS_DOWN_CAPABILITY_HPP
+#define BRIGHTNESS_DOWN_CAPABILITY_HPP
+
+#include <functional>
+
+#include "Capabilities/Capability.hpp"
+#include "EarController.hpp"
+
+class BrightnessDownCapability : public Capability
+{
+public:
+  BrightnessDownCapability(EarController &earController,
+                           std::function<void()> onSettingsChanged);
+
+  bool handle() override;
+
+private:
+  EarController &earController_;
+  std::function<void()> onSettingsChanged_;
+};
+
+#endif // BRIGHTNESS_DOWN_CAPABILITY_HPP

--- a/src/Capabilities/BrightnessUpCapability.cpp
+++ b/src/Capabilities/BrightnessUpCapability.cpp
@@ -1,0 +1,34 @@
+#include "Capabilities/BrightnessUpCapability.hpp"
+
+namespace
+{
+constexpr float kStepPercent = 20.0f;
+constexpr float kMaxPercent = 100.0f;
+}
+
+BrightnessUpCapability::BrightnessUpCapability(
+    EarController &earController,
+    std::function<void()> onSettingsChanged)
+    : Capability(F("brightness_up")),
+      earController_(earController),
+      onSettingsChanged_(onSettingsChanged)
+{
+}
+
+bool BrightnessUpCapability::handle()
+{
+  float nextBrightness = earController_.getBrightnessPercent() + kStepPercent;
+  if (nextBrightness > kMaxPercent)
+  {
+    nextBrightness = kMaxPercent;
+  }
+
+  earController_.setBrightnessPercent(nextBrightness);
+
+  if (onSettingsChanged_)
+  {
+    onSettingsChanged_();
+  }
+
+  return true;
+}

--- a/src/Capabilities/BrightnessUpCapability.hpp
+++ b/src/Capabilities/BrightnessUpCapability.hpp
@@ -1,0 +1,22 @@
+#ifndef BRIGHTNESS_UP_CAPABILITY_HPP
+#define BRIGHTNESS_UP_CAPABILITY_HPP
+
+#include <functional>
+
+#include "Capabilities/Capability.hpp"
+#include "EarController.hpp"
+
+class BrightnessUpCapability : public Capability
+{
+public:
+  BrightnessUpCapability(EarController &earController,
+                         std::function<void()> onSettingsChanged);
+
+  bool handle() override;
+
+private:
+  EarController &earController_;
+  std::function<void()> onSettingsChanged_;
+};
+
+#endif // BRIGHTNESS_UP_CAPABILITY_HPP

--- a/src/Capabilities/Capability.cpp
+++ b/src/Capabilities/Capability.cpp
@@ -1,0 +1,13 @@
+#include "Capabilities/Capability.hpp"
+
+#include <utility>
+
+Capability::Capability(String name)
+    : name_(std::move(name))
+{
+}
+
+const String &Capability::getName() const
+{
+  return name_;
+}

--- a/src/Capabilities/Capability.hpp
+++ b/src/Capabilities/Capability.hpp
@@ -1,0 +1,19 @@
+#ifndef CAPABILITY_HPP
+#define CAPABILITY_HPP
+
+#include <Arduino.h>
+
+class Capability
+{
+public:
+  explicit Capability(String name);
+  virtual ~Capability() = default;
+
+  const String &getName() const;
+  virtual bool handle() = 0;
+
+private:
+  String name_;
+};
+
+#endif // CAPABILITY_HPP

--- a/src/Capabilities/CapabilityManager.cpp
+++ b/src/Capabilities/CapabilityManager.cpp
@@ -1,0 +1,41 @@
+#include "Capabilities/CapabilityManager.hpp"
+
+#include "Capabilities/BrightnessDownCapability.hpp"
+#include "Capabilities/BrightnessUpCapability.hpp"
+
+CapabilityManager::CapabilityManager(EarController &earController,
+                                     std::function<void()> onSettingsChanged)
+{
+  capabilities_.push_back(std::make_unique<BrightnessUpCapability>(
+      earController,
+      onSettingsChanged));
+  capabilities_.push_back(std::make_unique<BrightnessDownCapability>(
+      earController,
+      onSettingsChanged));
+}
+
+Capability *CapabilityManager::getCapabilityByName(const String &name) const
+{
+  for (const auto &capability : capabilities_)
+  {
+    if (capability->getName() == name)
+    {
+      return capability.get();
+    }
+  }
+
+  return nullptr;
+}
+
+std::vector<String> CapabilityManager::getAvailableCapabilities() const
+{
+  std::vector<String> capabilityNames;
+  capabilityNames.reserve(capabilities_.size());
+
+  for (const auto &capability : capabilities_)
+  {
+    capabilityNames.push_back(capability->getName());
+  }
+
+  return capabilityNames;
+}

--- a/src/Capabilities/CapabilityManager.hpp
+++ b/src/Capabilities/CapabilityManager.hpp
@@ -1,0 +1,24 @@
+#ifndef CAPABILITY_MANAGER_HPP
+#define CAPABILITY_MANAGER_HPP
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "Capabilities/Capability.hpp"
+#include "EarController.hpp"
+
+class CapabilityManager
+{
+public:
+  CapabilityManager(EarController &earController,
+                    std::function<void()> onSettingsChanged);
+
+  Capability *getCapabilityByName(const String &name) const;
+  std::vector<String> getAvailableCapabilities() const;
+
+private:
+  std::vector<std::unique_ptr<Capability>> capabilities_;
+};
+
+#endif // CAPABILITY_MANAGER_HPP

--- a/src/WebEndpoints/Capabilities/CapabilitiesEndpoint.cpp
+++ b/src/WebEndpoints/Capabilities/CapabilitiesEndpoint.cpp
@@ -1,0 +1,32 @@
+#include "WebEndpoints/Capabilities/CapabilitiesEndpoint.hpp"
+
+#include <ArduinoJson.h>
+
+CapabilitiesEndpoint::CapabilitiesEndpoint(CapabilityManager &capabilityManager)
+    : capabilityManager_(capabilityManager)
+{
+}
+
+void CapabilitiesEndpoint::registerEndpoint(AsyncWebServer &server)
+{
+  server.on("/capabilities", HTTP_GET, [this](AsyncWebServerRequest *request)
+            { handleGet(request); });
+}
+
+void CapabilitiesEndpoint::handleGet(AsyncWebServerRequest *request)
+{
+  const auto capabilities = capabilityManager_.getAvailableCapabilities();
+
+  JsonDocument document;
+  JsonArray capabilitiesArray = document["capabilities"].to<JsonArray>();
+
+  for (const auto &capability : capabilities)
+  {
+    capabilitiesArray.add(capability);
+  }
+
+  String json;
+  serializeJson(document, json);
+
+  request->send(200, "application/json", json);
+}

--- a/src/WebEndpoints/Capabilities/CapabilitiesEndpoint.hpp
+++ b/src/WebEndpoints/Capabilities/CapabilitiesEndpoint.hpp
@@ -1,0 +1,21 @@
+#ifndef WEB_ENDPOINTS_CAPABILITIES_CAPABILITIES_ENDPOINT_HPP
+#define WEB_ENDPOINTS_CAPABILITIES_CAPABILITIES_ENDPOINT_HPP
+
+#include <ESPAsyncWebServer.h>
+
+#include "Capabilities/CapabilityManager.hpp"
+
+class CapabilitiesEndpoint
+{
+public:
+  explicit CapabilitiesEndpoint(CapabilityManager &capabilityManager);
+
+  void registerEndpoint(AsyncWebServer &server);
+
+private:
+  void handleGet(AsyncWebServerRequest *request);
+
+  CapabilityManager &capabilityManager_;
+};
+
+#endif // WEB_ENDPOINTS_CAPABILITIES_CAPABILITIES_ENDPOINT_HPP

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -18,6 +18,8 @@ WebServerManager::WebServerManager(
       fanEndpoint_(fanController, onSettingsChanged),
       earsEndpoint_(earController, onSettingsChanged),
       gyroEndpoint_(tiltController),
+      capabilityManager_(earController, onSettingsChanged),
+      capabilitiesEndpoint_(capabilityManager_),
       notFoundEndpoint_()
 {
 }
@@ -49,5 +51,6 @@ void WebServerManager::registerRoutes()
   fanEndpoint_.registerEndpoint(server_);
   earsEndpoint_.registerEndpoint(server_);
   gyroEndpoint_.registerEndpoint(server_);
+  capabilitiesEndpoint_.registerEndpoint(server_);
   notFoundEndpoint_.registerEndpoint(server_);
 }

--- a/src/WebServerManager.hpp
+++ b/src/WebServerManager.hpp
@@ -20,6 +20,8 @@
 #include "WebEndpoints/Files/FileEndpoint.hpp"
 #include "WebEndpoints/Files/FilesEndpoint.hpp"
 #include "WebEndpoints/System/GyroEndpoint.hpp"
+#include "Capabilities/CapabilityManager.hpp"
+#include "WebEndpoints/Capabilities/CapabilitiesEndpoint.hpp"
 #include "WebEndpoints/System/HeapEndpoint.hpp"
 #include "WebEndpoints/System/NotFoundEndpoint.hpp"
 #include "WebEndpoints/System/StaticContentEndpoint.hpp"
@@ -47,6 +49,8 @@ private:
   FanEndpoint fanEndpoint_;
   EarsEndpoint earsEndpoint_;
   GyroEndpoint gyroEndpoint_;
+  CapabilityManager capabilityManager_;
+  CapabilitiesEndpoint capabilitiesEndpoint_;
   NotFoundEndpoint notFoundEndpoint_;
 };
 

--- a/test/http-files/Capabilities.http
+++ b/test/http-files/Capabilities.http
@@ -1,0 +1,2 @@
+### Get all available remote-control capabilities
+GET http://192.168.4.1/capabilities


### PR DESCRIPTION
### Motivation
- Provide a generic, extensible way to manage remote-control actions (capabilities) for the device and expose what actions are available over the network.
- Implement basic brightness control actions as the first concrete capabilities so remote controllers can adjust ear brightness in fixed steps.

### Description
- Add an abstract `Capability` base class with a `name` and pure virtual `handle()` to define the capability contract (`src/Capabilities/Capability.hpp`, `src/Capabilities/Capability.cpp`).
- Implement `BrightnessUpCapability` and `BrightnessDownCapability` that adjust ear brightness by `20%` steps and call the provided `onSettingsChanged` callback (`src/Capabilities/BrightnessUpCapability.*`, `src/Capabilities/BrightnessDownCapability.*`).
- Add `CapabilityManager` that instantiates and owns available capabilities, exposes `getCapabilityByName()` and `getAvailableCapabilities()` (`src/Capabilities/CapabilityManager.*`).
- Add `GET /capabilities` JSON endpoint that returns available capability names under the `capabilities` array and wire it into `WebServerManager` so the route is registered on startup (`src/WebEndpoints/Capabilities/*`, `src/WebServerManager.*`).
- Include an HTTP request example for the new endpoint at `test/http-files/Capabilities.http`.

### Testing
- Attempted a workspace build with `pio run` but the command could not be executed because PlatformIO (`pio`) is not installed in this environment.
- No automated unit tests were executed in this environment due to the missing PlatformIO toolchain.
- An HTTP example request file `test/http-files/Capabilities.http` was added to exercise the new `GET /capabilities` endpoint during integration testing on-device or in a CI environment with network access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f18ab01c832da96dfe360bb30cb6)