### PR TITLE
Add BLE capability discovery and invocation support

### DIFF
--- a/src/BLEController.cpp
+++ b/src/BLEController.cpp
@@ -1,8 +1,8 @@
 #include "BLEController.hpp"
 #include "NimBLEDevice.h"
 
-BLEController::CharacteristicCallbacks::CharacteristicCallbacks(EmotionState &emotionState)
-    : emotionState_(emotionState)
+BLEController::CharacteristicCallbacks::CharacteristicCallbacks(EmotionState &emotionState, CapabilityManager &capabilityManager)
+    : emotionState_(emotionState), capabilityManager_(capabilityManager)
 {
 }
 
@@ -24,13 +24,37 @@ void BLEController::CharacteristicCallbacks::onWrite(NimBLECharacteristic *pChar
 
     if (characteristicValue.charAt(0) == '?')
     {
+        auto capabilities = capabilityManager_.getAvailableCapabilities();
         String availableEmotionsMessage;
+        String availableCapabilitiesMessage;
+
         for (int i = 0; i < emotionCount; i++)
         {
             auto emotion = emotions[i];
             availableEmotionsMessage += emotion.name;
             availableEmotionsMessage += ";";
         }
+
+        for (const auto &capability : capabilities)
+        {
+            availableCapabilitiesMessage += capability;
+            availableCapabilitiesMessage += ";";
+        }
+
+        if (characteristicValue == "?cap")
+        {
+            pCharacteristic->setValue(availableCapabilitiesMessage);
+            pCharacteristic->notify(true);
+            return;
+        }
+
+        if (characteristicValue == "?all")
+        {
+            pCharacteristic->setValue("E:" + availableEmotionsMessage + "|C:" + availableCapabilitiesMessage);
+            pCharacteristic->notify(true);
+            return;
+        }
+
         pCharacteristic->setValue(availableEmotionsMessage);
         pCharacteristic->notify(true);
         return;
@@ -38,13 +62,39 @@ void BLEController::CharacteristicCallbacks::onWrite(NimBLECharacteristic *pChar
 
     if (characteristicValue.charAt(0) == ';')
     { // command
-        if (characteristicValue.indexOf("rgb") > 0)
+        if (characteristicValue.startsWith(";cap:"))
+        {
+            auto capabilityName = characteristicValue.substring(5);
+            auto capability = capabilityManager_.getCapabilityByName(capabilityName);
+            if (capability == nullptr)
+            {
+                Serial.println("[W] Unknown capability: " + capabilityName);
+                return;
+            }
+
+            capability->handle();
+        }
+        else if (characteristicValue.indexOf("rgb") > 0)
         {
             //TODO: Use this for ear color
         }
         else if (characteristicValue.indexOf("set") > 0)
         {
             //TODO: Use this for ear brightness
+        }
+        else
+        {
+            auto emotionName = characteristicValue.substring(1);
+            for (int i = 0; i < emotionCount; i++)
+            {
+                auto emotion = emotions[i];
+                if (emotionName == emotion.name)
+                {
+                    Serial.println("[I] Setting emotion" + emotion.path);
+                    emotionState_.setCurrentEmotion(emotion.path);
+                    return;
+                }
+            }
         }
         return;
     }
@@ -76,8 +126,8 @@ class ServerCallbacks : public NimBLEServerCallbacks
     }
 } serverCallbacks;
 
-BLEController::BLEController(EmotionState &emotionState)
-  :  emotionState_(emotionState)
+BLEController::BLEController(EmotionState &emotionState, CapabilityManager &capabilityManager)
+  :  emotionState_(emotionState), capabilityManager_(capabilityManager)
 {
 }
 
@@ -99,7 +149,7 @@ bool BLEController::begin()
                                                          NIMBLE_PROPERTY::INDICATE);
     pCharacteristic->setValue(emotions.size());
 
-    auto chrCallbacks = new CharacteristicCallbacks(emotionState_);
+    auto chrCallbacks = new CharacteristicCallbacks(emotionState_, capabilityManager_);
 
     pCharacteristic->setCallbacks(chrCallbacks);
 

--- a/src/BLEController.cpp
+++ b/src/BLEController.cpp
@@ -15,6 +15,11 @@ void BLEController::CharacteristicCallbacks::onWrite(NimBLECharacteristic *pChar
 
     Serial.println("[I] BT Received: " + String(characteristicValue));
 
+    if (characteristicValue.length() == 0)
+    {
+        return;
+    }
+
     if (characteristicValue.charAt(0) == 'g')
     { // legacy remote reasons
         pCharacteristic->setValue("i" + String(emotionCount));

--- a/src/BLEController.hpp
+++ b/src/BLEController.hpp
@@ -4,13 +4,14 @@
 #include "NimBLEDevice.h"
 #include "FileManager.hpp"
 #include "EmotionState.hpp"
+#include "Capabilities/CapabilityManager.hpp"
 
 #include <Arduino.h>
 
 class BLEController 
 {
     public:
-        BLEController(EmotionState &emotionState);
+        BLEController(EmotionState &emotionState, CapabilityManager &capabilityManager);
         bool begin();
         void update();
     private:
@@ -18,14 +19,16 @@ class BLEController
         BLECharacteristic * pCharacteristic;
         BLEAdvertising* pAdvertising;
         EmotionState &emotionState_;
+        CapabilityManager &capabilityManager_;
 
         class CharacteristicCallbacks : public NimBLECharacteristicCallbacks {
             public:
-                CharacteristicCallbacks(EmotionState &emotionState);
+                CharacteristicCallbacks(EmotionState &emotionState, CapabilityManager &capabilityManager);
                 void onWrite(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo &connInfo) override;
 
             private:
                 EmotionState &emotionState_;
+                CapabilityManager &capabilityManager_;
         };
 };
 

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -6,6 +6,7 @@ WebServerManager::WebServerManager(
     EarController &earController,
     TiltController &tiltController,
     FileManager &fileManager,
+    CapabilityManager &capabilityManager,
     std::function<void()> onSettingsChanged,
     bool allowAllFileChanges)
     : server_(80),
@@ -18,8 +19,7 @@ WebServerManager::WebServerManager(
       fanEndpoint_(fanController, onSettingsChanged),
       earsEndpoint_(earController, onSettingsChanged),
       gyroEndpoint_(tiltController),
-      capabilityManager_(earController, onSettingsChanged),
-      capabilitiesEndpoint_(capabilityManager_),
+      capabilitiesEndpoint_(capabilityManager),
       notFoundEndpoint_()
 {
 }

--- a/src/WebServerManager.hpp
+++ b/src/WebServerManager.hpp
@@ -31,6 +31,7 @@ public:
   WebServerManager(EmotionState &emotionState, FanController &fanController,
                    EarController &earController, TiltController &tiltController,
                    FileManager &fileManager,
+                   CapabilityManager &capabilityManager,
                    std::function<void()> onSettingsChanged, bool allowAllFileChanges);
 
   void begin(const char *ssid, const char *password);
@@ -49,7 +50,6 @@ private:
   FanEndpoint fanEndpoint_;
   EarsEndpoint earsEndpoint_;
   GyroEndpoint gyroEndpoint_;
-  CapabilityManager capabilityManager_;
   CapabilitiesEndpoint capabilitiesEndpoint_;
   NotFoundEndpoint notFoundEndpoint_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "TiltController.hpp"
 #include "WebServerManager.hpp"
 #include "BLEController.hpp"
+#include "Capabilities/CapabilityManager.hpp"
 
 // Display configuration
 constexpr int PANEL_RES_X = 64;
@@ -53,8 +54,9 @@ WebServerManager webServerManager(emotionState, fanController, earController,
                                   tiltController, fileManager,
                                   onSettingsChanged, 
                                   ALLOW_ALL_FILE_CHANGES);
+CapabilityManager capabilityManager(earController, onSettingsChanged);
 DisplayManager displayManager(PIN_SDA, PIN_SCL, emotionState, fanController, earController);
-BLEController bleController(emotionState); 
+BLEController bleController(emotionState, capabilityManager); 
 
 void setup() {
   Serial.begin(115200);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,11 +50,12 @@ void onSettingsChanged()
 {
   settingsStorage.save();
 }
+CapabilityManager capabilityManager(earController, onSettingsChanged);
 WebServerManager webServerManager(emotionState, fanController, earController,
                                   tiltController, fileManager,
+                                  capabilityManager,
                                   onSettingsChanged, 
                                   ALLOW_ALL_FILE_CHANGES);
-CapabilityManager capabilityManager(earController, onSettingsChanged);
 DisplayManager displayManager(PIN_SDA, PIN_SCL, emotionState, fanController, earController);
 BLEController bleController(emotionState, capabilityManager); 
 


### PR DESCRIPTION
### Motivation
- The Bluetooth remote protocol gained new features to enumerate and invoke device capabilities and to request combined listings of emotions and capabilities.
- The BLE controller needs access to the `CapabilityManager` to expose capabilities over BT and to invoke existing capability handlers remotely.

### Description
- Extend `BLEController` to accept a `CapabilityManager &` and store it, and update `CharacteristicCallbacks` constructor to receive the capability manager reference.
- Add BLE query handling so `?cap` returns capabilities-only and `?all` returns a categorized string `E:<emotions>|C:<capabilities>`, while plain `?` falls back to the existing emotions-only response.
- Add BLE command handling so `;cap:<name>` looks up `CapabilityManager::getCapabilityByName` and calls `handle()` on the found capability, and `;<name>` switches emotion by name (preserving legacy numeric/name behaviors).
- Wire a `CapabilityManager` instance in `main.cpp` and pass it into `BLEController` so BLE callbacks can query and invoke capabilities.

### Testing
- Attempted to build with `platformio run`, but the command failed in this environment with `platformio: command not found`, so no successful automated build/test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50816b510832d8a9d72156ea0444a)