### PR TITLE
Add fan_speed_up and fan_speed_down capabilities (20% steps)

### DIFF
--- a/src/Capabilities/CapabilityManager.cpp
+++ b/src/Capabilities/CapabilityManager.cpp
@@ -2,14 +2,17 @@
 
 #include "Capabilities/BrightnessDownCapability.hpp"
 #include "Capabilities/BrightnessUpCapability.hpp"
-
-
+#include "Capabilities/FanSpeedDownCapability.hpp"
+#include "Capabilities/FanSpeedUpCapability.hpp"
 
 CapabilityManager::CapabilityManager(EarController &earController,
+                                     FanController &fanController,
                                      std::function<void()> onSettingsChanged)
 {
   capabilities_.push_back(std::unique_ptr<BrightnessUpCapability>(new BrightnessUpCapability(earController, onSettingsChanged)));
   capabilities_.push_back(std::unique_ptr<BrightnessDownCapability>(new BrightnessDownCapability(earController, onSettingsChanged)));
+  capabilities_.push_back(std::unique_ptr<FanSpeedUpCapability>(new FanSpeedUpCapability(fanController, onSettingsChanged)));
+  capabilities_.push_back(std::unique_ptr<FanSpeedDownCapability>(new FanSpeedDownCapability(fanController, onSettingsChanged)));
 }
 
 Capability *CapabilityManager::getCapabilityByName(const String &name) const

--- a/src/Capabilities/CapabilityManager.hpp
+++ b/src/Capabilities/CapabilityManager.hpp
@@ -7,11 +7,13 @@
 
 #include "Capabilities/Capability.hpp"
 #include "EarController.hpp"
+#include "FanController.hpp"
 
 class CapabilityManager
 {
 public:
   CapabilityManager(EarController &earController,
+                    FanController &fanController,
                     std::function<void()> onSettingsChanged);
 
   Capability *getCapabilityByName(const String &name) const;

--- a/src/Capabilities/FanSpeedDownCapability.cpp
+++ b/src/Capabilities/FanSpeedDownCapability.cpp
@@ -1,0 +1,34 @@
+#include "Capabilities/FanSpeedDownCapability.hpp"
+
+namespace
+{
+constexpr float kStepPercent = 20.0f;
+constexpr float kMinPercent = 0.0f;
+}
+
+FanSpeedDownCapability::FanSpeedDownCapability(
+    FanController &fanController,
+    std::function<void()> onSettingsChanged)
+    : Capability(F("fan_speed_down")),
+      fanController_(fanController),
+      onSettingsChanged_(onSettingsChanged)
+{
+}
+
+bool FanSpeedDownCapability::handle()
+{
+  float nextDutyCycle = fanController_.getDutyCyclePercent() - kStepPercent;
+  if (nextDutyCycle < kMinPercent)
+  {
+    nextDutyCycle = kMinPercent;
+  }
+
+  fanController_.setDutyCyclePercent(nextDutyCycle);
+
+  if (onSettingsChanged_)
+  {
+    onSettingsChanged_();
+  }
+
+  return true;
+}

--- a/src/Capabilities/FanSpeedDownCapability.hpp
+++ b/src/Capabilities/FanSpeedDownCapability.hpp
@@ -1,0 +1,22 @@
+#ifndef FAN_SPEED_DOWN_CAPABILITY_HPP
+#define FAN_SPEED_DOWN_CAPABILITY_HPP
+
+#include <functional>
+
+#include "Capabilities/Capability.hpp"
+#include "FanController.hpp"
+
+class FanSpeedDownCapability : public Capability
+{
+public:
+  FanSpeedDownCapability(FanController &fanController,
+                         std::function<void()> onSettingsChanged);
+
+  bool handle() override;
+
+private:
+  FanController &fanController_;
+  std::function<void()> onSettingsChanged_;
+};
+
+#endif // FAN_SPEED_DOWN_CAPABILITY_HPP

--- a/src/Capabilities/FanSpeedUpCapability.cpp
+++ b/src/Capabilities/FanSpeedUpCapability.cpp
@@ -1,0 +1,34 @@
+#include "Capabilities/FanSpeedUpCapability.hpp"
+
+namespace
+{
+constexpr float kStepPercent = 20.0f;
+constexpr float kMaxPercent = 100.0f;
+}
+
+FanSpeedUpCapability::FanSpeedUpCapability(
+    FanController &fanController,
+    std::function<void()> onSettingsChanged)
+    : Capability(F("fan_speed_up")),
+      fanController_(fanController),
+      onSettingsChanged_(onSettingsChanged)
+{
+}
+
+bool FanSpeedUpCapability::handle()
+{
+  float nextDutyCycle = fanController_.getDutyCyclePercent() + kStepPercent;
+  if (nextDutyCycle > kMaxPercent)
+  {
+    nextDutyCycle = kMaxPercent;
+  }
+
+  fanController_.setDutyCyclePercent(nextDutyCycle);
+
+  if (onSettingsChanged_)
+  {
+    onSettingsChanged_();
+  }
+
+  return true;
+}

--- a/src/Capabilities/FanSpeedUpCapability.hpp
+++ b/src/Capabilities/FanSpeedUpCapability.hpp
@@ -1,0 +1,22 @@
+#ifndef FAN_SPEED_UP_CAPABILITY_HPP
+#define FAN_SPEED_UP_CAPABILITY_HPP
+
+#include <functional>
+
+#include "Capabilities/Capability.hpp"
+#include "FanController.hpp"
+
+class FanSpeedUpCapability : public Capability
+{
+public:
+  FanSpeedUpCapability(FanController &fanController,
+                       std::function<void()> onSettingsChanged);
+
+  bool handle() override;
+
+private:
+  FanController &fanController_;
+  std::function<void()> onSettingsChanged_;
+};
+
+#endif // FAN_SPEED_UP_CAPABILITY_HPP

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -24,10 +24,24 @@ bool FanController::setDutyCycle(int dutyCycle) {
   return true;
 }
 
+
+
+bool FanController::setDutyCyclePercent(float percent) {
+  if (percent < 0.0f || percent > 100.0f) {
+    return false;
+  }
+
+  const int maxValue = getMaxDutyCycle();
+  const int dutyCycle = static_cast<int>((percent / 100.0f) * static_cast<float>(maxValue));
+  return setDutyCycle(dutyCycle);
+}
+
 int FanController::getDutyCycle() const { return dutyCycle_; }
 
+int FanController::getMaxDutyCycle() const { return (1 << resolution_) - 1; }
+
 float FanController::getDutyCyclePercent() const {
-  const int maxValue = (1 << resolution_) - 1;
+  const int maxValue = getMaxDutyCycle();
   if (maxValue <= 0) {
     return 0.0f;
   }

--- a/src/FanController.hpp
+++ b/src/FanController.hpp
@@ -9,7 +9,9 @@ public:
 
   void begin();
   bool setDutyCycle(int dutyCycle);
+  bool setDutyCyclePercent(float percent);
   int getDutyCycle() const;
+  int getMaxDutyCycle() const;
   float getDutyCyclePercent() const;
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ void onSettingsChanged()
 {
   settingsStorage.save();
 }
-CapabilityManager capabilityManager(earController, onSettingsChanged);
+CapabilityManager capabilityManager(earController, fanController, onSettingsChanged);
 WebServerManager webServerManager(emotionState, fanController, earController,
                                   tiltController, fileManager,
                                   capabilityManager,


### PR DESCRIPTION
### Motivation
- Expose remote-control capabilities to adjust the fan in discrete 20% steps and clamp to valid bounds (0%..100%).
- Reuse the existing capability framework so remotes/BLE can trigger fan adjustments the same way ear brightness is controlled.
- Provide a percent-based API on the PWM-backed `FanController` so capabilities can work in human-friendly 0–100% terms.

### Description
- Added two new capabilities: `fan_speed_up` and `fan_speed_down` with implementations in `src/Capabilities/FanSpeedUpCapability.*` and `src/Capabilities/FanSpeedDownCapability.*` that change fan speed by `20%` and clamp to `0%`/`100%`.
- Extended `FanController` with `bool setDutyCyclePercent(float percent)` and `int getMaxDutyCycle()` and adjusted internal percent calculations so percent values map to the PWM duty range (`src/FanController.*`).
- Updated `CapabilityManager` to accept a `FanController &` and register the two new fan capabilities (`src/Capabilities/CapabilityManager.*`).
- Updated wiring in `src/main.cpp` to construct `CapabilityManager` with `fanController` so the new capabilities are available at runtime.

### Testing
- Attempted to run `pio run` to build the project, but it failed in this environment because PlatformIO CLI is not installed (`pio: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e526eee944832dab8a57fe5ba4eb6b)