### PR TITLE
Add GET /files/info endpoint for data partition usage

### DIFF
--- a/src/FileManager.cpp
+++ b/src/FileManager.cpp
@@ -84,6 +84,16 @@ bool FileManager::exists(const String &path) const
   return LittleFS.exists(path);
 }
 
+size_t FileManager::totalBytes() const
+{
+  return LittleFS.totalBytes();
+}
+
+size_t FileManager::usedBytes() const
+{
+  return LittleFS.usedBytes();
+}
+
 bool FileManager::readFile(const String &path, String &content) const
 {
   File file = LittleFS.open(path, FILE_READ);

--- a/src/FileManager.hpp
+++ b/src/FileManager.hpp
@@ -15,6 +15,8 @@ public:
   void printEmotions() const;
 
   bool exists(const String &path) const;
+  size_t totalBytes() const;
+  size_t usedBytes() const;
   bool readFile(const String &path, String &content) const;
   bool writeFile(const String &path, const uint8_t *data, size_t len,
                  bool append = false) const;

--- a/src/WebEndpoints/Files/FilesEndpoint.cpp
+++ b/src/WebEndpoints/Files/FilesEndpoint.cpp
@@ -11,6 +11,8 @@ void FilesEndpoint::registerEndpoint(AsyncWebServer &server)
 {
   server.on("/files", HTTP_GET, [this](AsyncWebServerRequest *request)
             { handleGet(request); });
+  server.on("/files/info", HTTP_GET, [this](AsyncWebServerRequest *request)
+            { handleGetInfo(request); });
 }
 
 void FilesEndpoint::handleGet(AsyncWebServerRequest *request)
@@ -28,6 +30,30 @@ void FilesEndpoint::handleGet(AsyncWebServerRequest *request)
     JsonObject fileObject = files.add<JsonObject>();
     file.serialize(fileObject);
   }
+
+  String json;
+  serializeJson(document, json);
+
+  request->send(200, "application/json", json);
+}
+
+void FilesEndpoint::handleGetInfo(AsyncWebServerRequest *request)
+{
+  const size_t totalSizeBytes = fileManager_.totalBytes();
+  const size_t usedSizeBytes = fileManager_.usedBytes();
+
+  float usedPercentage = 0.0F;
+  if (totalSizeBytes > 0U)
+  {
+    usedPercentage = (static_cast<float>(usedSizeBytes) * 100.0F) /
+                     static_cast<float>(totalSizeBytes);
+  }
+
+  JsonDocument document;
+  JsonObject info = document.to<JsonObject>();
+  info["totalSizeBytes"] = totalSizeBytes;
+  info["usedSizeBytes"] = usedSizeBytes;
+  info["usedPercentage"] = usedPercentage;
 
   String json;
   serializeJson(document, json);

--- a/src/WebEndpoints/Files/FilesEndpoint.hpp
+++ b/src/WebEndpoints/Files/FilesEndpoint.hpp
@@ -13,6 +13,7 @@ public:
 
 private:
   void handleGet(AsyncWebServerRequest *request);
+  void handleGetInfo(AsyncWebServerRequest *request);
 
   FileManager &fileManager_;
 };

--- a/test/http-files/Files.http
+++ b/test/http-files/Files.http
@@ -3,6 +3,9 @@
 ### List uploaded animation files
 GET {{baseUrl}}/files
 
+### Get data partition usage info
+GET {{baseUrl}}/files/info
+
 ### Upload a test animation file
 # @name uploadTestAnimation
 POST {{baseUrl}}/file


### PR DESCRIPTION
### Motivation
- Provide an HTTP endpoint that reports LittleFS data partition statistics so clients can monitor total and used storage and calculate usage percentage.

### Description
- Added `FileManager::totalBytes()` and `FileManager::usedBytes()` which wrap `LittleFS.totalBytes()` and `LittleFS.usedBytes()` respectively.
- Registered a new route `GET /files/info` in `FilesEndpoint` and implemented `handleGetInfo(...)` to return a JSON object with `totalSizeBytes`, `usedSizeBytes`, and `usedPercentage`.
- `usedPercentage` is computed as `(used / total) * 100` and is guarded against division by zero (returns `0.0` when total is zero).
- Updated `test/http-files/Files.http` with an example request for the new endpoint.

### Testing
- Attempted to run `platformio run -e esp32dev`, but the build could not be executed because `platformio` is not installed in this environment (build failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf521e3cc832db6fbaa98e12280b3)