### PR TITLE
Add disk usage indicator to File Manager dashboard

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -434,6 +434,29 @@
       gap: 10px;
     }
 
+    .disk-usage {
+      margin-top: 12px;
+      padding: 12px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.78);
+      display: grid;
+      gap: 8px;
+    }
+
+    .disk-usage-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+      color: #2f3d4f;
+    }
+
+    .disk-usage progress {
+      width: 100%;
+      height: 14px;
+    }
+
     .file-item {
       display: flex;
       align-items: center;
@@ -577,6 +600,10 @@
 
     <section>
       <h2>File Manager</h2>
+      <div class="disk-usage">
+        <div id="diskUsageLabel" class="disk-usage-label">💾 Used: -- KB/ -- KB</div>
+        <progress id="diskUsageBar" value="0" max="100" aria-label="Disk usage"></progress>
+      </div>
       <form id="uploadForm">
         <div class="display-row">
           <label for="fileInput">File:</label>
@@ -689,6 +716,8 @@
       var uploadStatus = $("uploadStatus");
       var fileList = $("fileList");
       var filesStatus = $("filesStatus");
+      var diskUsageLabel = $("diskUsageLabel");
+      var diskUsageBar = $("diskUsageBar");
       var emotionCurrent = $("emotionCurrent");
       var emotionStatus = $("emotionStatus");
       var emotionList = $("emotionList");
@@ -1360,6 +1389,7 @@
           renderFileList(allFiles);
           updateEmotionFormOptions();
           setText(filesStatus, "");
+          refreshFilesInfo();
           return allFiles;
         }).catch(function (error) {
           allFiles = [];
@@ -1367,10 +1397,39 @@
           renderFileList([]);
           updateEmotionFormOptions();
           setText(filesStatus, "Error: " + error.message);
+          refreshFilesInfo();
           if (!emotionStatus.textContent) {
             setText(emotionStatus, "Error loading animation files: " + error.message);
           }
           return [];
+        });
+      }
+
+      function refreshFilesInfo() {
+        return fetchJson("/files-info").then(function (info) {
+          var payload = (info && typeof info === "object" && !Array.isArray(info)) ? info : {};
+          var usedKb = Number(payload.usedKb);
+          var availableKb = Number(payload.awailableKb);
+          if (!isFinite(availableKb)) {
+            availableKb = Number(payload.availableKb);
+          }
+
+          if (!isFinite(usedKb) || !isFinite(availableKb) || availableKb <= 0) {
+            throw new Error("Invalid files-info response.");
+          }
+
+          var clampedUsed = clamp(usedKb, 0, availableKb);
+          var percent = clamp((clampedUsed / availableKb) * 100, 0, 100);
+          diskUsageBar.max = 100;
+          diskUsageBar.value = percent;
+          setText(diskUsageLabel, "💾 Used: " + Math.round(clampedUsed) + " KB/ " + Math.round(availableKb) + " KB");
+        }).catch(function (error) {
+          diskUsageBar.max = 100;
+          diskUsageBar.value = 0;
+          setText(diskUsageLabel, "💾 Used: -- KB/ -- KB");
+          if (!filesStatus.textContent) {
+            setText(filesStatus, "Error: " + error.message);
+          }
         });
       }
 


### PR DESCRIPTION
### Motivation
- Show storage usage on the File Manager card so users can see remaining capacity at a glance, using the existing `files-info` endpoint and a non-editable horizontal bar with a hard-disk icon and label.

### Description
- Added a disk usage panel above the File Manager upload form containing a hard-disk icon label and a non-editable `<progress>` bar with the label format `Used: <used> KB/ <available> KB`.
- Added CSS rules for `.disk-usage`, `.disk-usage-label`, and the progress bar to match dashboard styling.
- Implemented `refreshFilesInfo()` which calls `GET /files-info`, parses `usedKb` and available capacity (uses `awailableKb` with a fallback to `availableKb`), clamps values, and updates the label and bar percentage.
- Wired `refreshFilesInfo()` into `refreshFiles()` and the initial load sequence so usage updates on page load and after file operations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0c2726e0832d9c364ae375757f49)