### PR TITLE
docs: expand README with project overview, capabilities, and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Project is a firmware for **ESP32-based Protogens**. It is intended to be modula
 ## What the UI provides
 The built-in web interface (served from `data/`) gives a quick control surface for:
 - switching the active emotion/animation,
+- configuring complex emotions that combine face-display animation with ear LED color/gradient profiles,
 - adjusting ear LED brightness,
 - controlling fan speed,
 - viewing basic device status and diagnostics,

--- a/README.md
+++ b/README.md
@@ -1,14 +1,47 @@
 # protogen-esp32
 
-Firmware for an **ESP32-Trinity-based Protogen** build with:
-- animated HUB75 face display output,
-- configurable RGB ear LEDs,
-- fan speed control,
-- IMU tilt telemetry,
-- local web API + static web UI,
-- BLE remote control,
-- LittleFS-backed animation + settings storage,
-- OTA update support.
+Project is a firmware for **ESP32-based Protogens**. It is intended to be modular and extensible, and can be controlled over a **Web UI**, **Bluetooth remote**, or **REST API**.
+
+## What the UI provides
+The built-in web interface (served from `data/`) gives a quick control surface for:
+- switching the active emotion/animation,
+- adjusting ear LED brightness,
+- controlling fan speed,
+- viewing basic device status and diagnostics,
+- managing files/emotion assets without reflashing firmware.
+
+The same functionality is also exposed by HTTP endpoints for automation and external apps.
+
+## Capabilities
+
+### Emotion playback and management
+- Load and play animation files from LittleFS.
+- Query and set the active emotion.
+- Create/update/delete emotion definitions (including ear color/gradient metadata).
+
+### Ear LED controls
+- Read current ear state.
+- Set brightness as percent or raw 0-255 value.
+
+### Fan controls
+- Read current duty cycle.
+- Set duty cycle over HTTP endpoint.
+
+### File management
+- Upload animation assets.
+- List files and data partition usage.
+- Read/delete files.
+
+### System and diagnostics
+- Heap usage endpoint.
+- Gyro/tilt endpoint.
+- Static content hosting from `data/`.
+- OTA updates through ElegantOTA.
+
+### BLE remote control
+- Query available emotions/capabilities.
+- Switch emotion.
+- Trigger named capabilities (brightness up/down, fan speed up/down).
 
 ## Hardware/firmware architecture
 
@@ -21,38 +54,7 @@ The firmware composes several controllers and managers:
 - `BLEController` exposes a BLE service/characteristic for remote commands.
 - `SettingsStorage` persists runtime-adjustable settings.
 
-See `src/main.cpp` for system wiring and startup order.
-
-## Capabilities
-
-### 1) Emotion playback and management
-- Load and play animation files from LittleFS.
-- Query and set the active emotion.
-- Create/update/delete emotion definitions (including ear color/gradient metadata).
-
-### 2) Ear LED controls
-- Read current ear state.
-- Set brightness as percent or raw 0-255 value.
-
-### 3) Fan controls
-- Read current duty cycle.
-- Set duty cycle over HTTP endpoint.
-
-### 4) File management
-- Upload animation assets.
-- List files and data partition usage.
-- Read/delete files.
-
-### 5) System and diagnostics
-- Heap usage endpoint.
-- Gyro/tilt endpoint.
-- Static content hosting from `data/`.
-- OTA updates through ElegantOTA.
-
-### 6) BLE remote control
-- Query available emotions/capabilities.
-- Switch emotion.
-- Trigger named capabilities (brightness up/down, fan speed up/down).
+See `src/main.cpp` for wiring and startup order.
 
 ## Web/API endpoints
 
@@ -70,72 +72,38 @@ Base URL (default AP): `http://192.168.4.1`
 - `GET /files-info`
 - `GET|POST|DELETE /file`
 
-Ready-to-run API samples are included in `test/http-files/*.http`.
+Ready-to-run API samples are in `test/http-files/*.http`.
 
 ## Tools and dependencies
 
-### Build system
-- [PlatformIO](https://platformio.org/) using Arduino framework (`espressif32` platform).
+- Build: [PlatformIO](https://platformio.org/) (Arduino framework, `espressif32`).
+- Core libs: `ESPAsyncWebServer`, `AsyncTCP`, `ElegantOTA`, `NimBLE-Arduino`, `ArduinoJson`, `ESP32-HUB75-MatrixPanel-DMA`, `AnimatedGIF`, `MPU6050_tockn`, `Adafruit_NeoPixel`, `Adafruit GFX`, `Adafruit SSD1306`, `esp32-sh1106-oled`.
+- Exact versions/sources: `platformio.ini`.
 
-### Key libraries
-- `ESPAsyncWebServer` + `AsyncTCP`
-- `ElegantOTA`
-- `NimBLE-Arduino`
-- `ArduinoJson`
-- `ESP32-HUB75-MatrixPanel-DMA`
-- `AnimatedGIF`
-- `MPU6050_tockn`
-- `Adafruit_NeoPixel`
-- `Adafruit GFX` + `Adafruit SSD1306` + `esp32-sh1106-oled`
+## Setup (compact)
 
-(Exact versions/sources are in `platformio.ini`.)
-
-## Setup
-
-## 1) Prerequisites
-- VS Code + PlatformIO extension **or** PlatformIO Core CLI installed.
-- ESP32 board connected over USB.
-
-## 2) Clone and open project
-```bash
-git clone <your-fork-or-repo-url>
-cd protogen-esp32
-```
-
-## 3) Configure Wi‑Fi AP credentials
-Edit `src/main.cpp`:
-- `WIFI_NAME`
-- `WIFI_PASS`
-
-You can also adjust pin mappings and panel parameters there.
-
-## 4) Build firmware
-```bash
-pio run
-```
-
-## 5) Upload firmware
-```bash
-pio run -t upload
-```
-
-## 6) Upload static files (LittleFS)
-```bash
-pio run -t uploadfs
-```
-
-## 7) Open serial monitor
-```bash
-pio device monitor -b 115200
-```
-
-## 8) Connect and test
-1. Connect to the ESP32 AP (default SSID from `WIFI_NAME`).
-2. Open `http://192.168.4.1`.
-3. Exercise endpoints using `test/http-files/*.http`.
+1. Install PlatformIO (VS Code extension or CLI).
+2. Clone and enter the repo:
+   ```bash
+   git clone <your-fork-or-repo-url>
+   cd protogen-esp32
+   ```
+3. Optional: edit `WIFI_NAME` / `WIFI_PASS` in `src/main.cpp`.
+4. Build + flash + filesystem:
+   ```bash
+   pio run
+   pio run -t upload
+   pio run -t uploadfs
+   ```
+5. Monitor serial output:
+   ```bash
+   pio device monitor -b 115200
+   ```
+6. Connect to the AP and open `http://192.168.4.1`.
 
 ## OTA updates
-Once running, OTA is enabled via ElegantOTA on the async web server. Use the web interface endpoint exposed by ElegantOTA to upload new firmware/images.
+
+OTA is enabled via ElegantOTA on the async web server.
 
 ## Project layout
 
@@ -145,5 +113,6 @@ Once running, OTA is enabled via ElegantOTA on the async web server. Use the web
 - `platformio.ini` - board/env config and dependencies
 
 ## Notes
-- This project currently defaults to `ALLOW_ALL_FILE_CHANGES = true` in `src/main.cpp`; review before production use.
+
+- Default `ALLOW_ALL_FILE_CHANGES = true` in `src/main.cpp`; review before production use.
 - Consider moving credentials out of source code for shared/public deployments.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,149 @@
 # protogen-esp32
-Software for protogen based on ESP32-Trinity board
+
+Firmware for an **ESP32-Trinity-based Protogen** build with:
+- animated HUB75 face display output,
+- configurable RGB ear LEDs,
+- fan speed control,
+- IMU tilt telemetry,
+- local web API + static web UI,
+- BLE remote control,
+- LittleFS-backed animation + settings storage,
+- OTA update support.
+
+## Hardware/firmware architecture
+
+The firmware composes several controllers and managers:
+- `FaceDisplay` renders animation files to a chained 64x32 HUB75 matrix setup.
+- `EarController` drives ear LEDs (NeoPixel-compatible strip/ring).
+- `FanController` controls fan speed through PWM.
+- `TiltController` reads motion/tilt data over I2C.
+- `WebServerManager` serves the API and static web assets over Wi‑Fi AP mode.
+- `BLEController` exposes a BLE service/characteristic for remote commands.
+- `SettingsStorage` persists runtime-adjustable settings.
+
+See `src/main.cpp` for system wiring and startup order.
+
+## Capabilities
+
+### 1) Emotion playback and management
+- Load and play animation files from LittleFS.
+- Query and set the active emotion.
+- Create/update/delete emotion definitions (including ear color/gradient metadata).
+
+### 2) Ear LED controls
+- Read current ear state.
+- Set brightness as percent or raw 0-255 value.
+
+### 3) Fan controls
+- Read current duty cycle.
+- Set duty cycle over HTTP endpoint.
+
+### 4) File management
+- Upload animation assets.
+- List files and data partition usage.
+- Read/delete files.
+
+### 5) System and diagnostics
+- Heap usage endpoint.
+- Gyro/tilt endpoint.
+- Static content hosting from `data/`.
+- OTA updates through ElegantOTA.
+
+### 6) BLE remote control
+- Query available emotions/capabilities.
+- Switch emotion.
+- Trigger named capabilities (brightness up/down, fan speed up/down).
+
+## Web/API endpoints
+
+Base URL (default AP): `http://192.168.4.1`
+
+- `GET /heap`
+- `GET /gyro`
+- `GET /emotions`
+- `GET|POST|PUT|DELETE /emotion`
+- `PUT /emotion/current`
+- `GET|PUT /fan`
+- `GET|PUT /ears`
+- `GET /capabilities`
+- `GET /files`
+- `GET /files-info`
+- `GET|POST|DELETE /file`
+
+Ready-to-run API samples are included in `test/http-files/*.http`.
+
+## Tools and dependencies
+
+### Build system
+- [PlatformIO](https://platformio.org/) using Arduino framework (`espressif32` platform).
+
+### Key libraries
+- `ESPAsyncWebServer` + `AsyncTCP`
+- `ElegantOTA`
+- `NimBLE-Arduino`
+- `ArduinoJson`
+- `ESP32-HUB75-MatrixPanel-DMA`
+- `AnimatedGIF`
+- `MPU6050_tockn`
+- `Adafruit_NeoPixel`
+- `Adafruit GFX` + `Adafruit SSD1306` + `esp32-sh1106-oled`
+
+(Exact versions/sources are in `platformio.ini`.)
+
+## Setup
+
+## 1) Prerequisites
+- VS Code + PlatformIO extension **or** PlatformIO Core CLI installed.
+- ESP32 board connected over USB.
+
+## 2) Clone and open project
+```bash
+git clone <your-fork-or-repo-url>
+cd protogen-esp32
+```
+
+## 3) Configure Wi‑Fi AP credentials
+Edit `src/main.cpp`:
+- `WIFI_NAME`
+- `WIFI_PASS`
+
+You can also adjust pin mappings and panel parameters there.
+
+## 4) Build firmware
+```bash
+pio run
+```
+
+## 5) Upload firmware
+```bash
+pio run -t upload
+```
+
+## 6) Upload static files (LittleFS)
+```bash
+pio run -t uploadfs
+```
+
+## 7) Open serial monitor
+```bash
+pio device monitor -b 115200
+```
+
+## 8) Connect and test
+1. Connect to the ESP32 AP (default SSID from `WIFI_NAME`).
+2. Open `http://192.168.4.1`.
+3. Exercise endpoints using `test/http-files/*.http`.
+
+## OTA updates
+Once running, OTA is enabled via ElegantOTA on the async web server. Use the web interface endpoint exposed by ElegantOTA to upload new firmware/images.
+
+## Project layout
+
+- `src/` - firmware modules (controllers, endpoints, models, capabilities)
+- `data/` - static web assets and animation files copied to LittleFS
+- `test/http-files/` - HTTP request collections for manual endpoint testing
+- `platformio.ini` - board/env config and dependencies
+
+## Notes
+- This project currently defaults to `ALLOW_ALL_FILE_CHANGES = true` in `src/main.cpp`; review before production use.
+- Consider moving credentials out of source code for shared/public deployments.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Base URL (default AP): `http://192.168.4.1`
 - `GET /capabilities`
 - `GET /files`
 - `GET /files-info`
-- `GET|POST|DELETE /file`
+- `GET|POST|PUT|DELETE /file`
 
 Ready-to-run API samples are in `test/http-files/*.http`.
 
@@ -113,7 +113,3 @@ OTA is enabled via ElegantOTA on the async web server.
 - `test/http-files/` - HTTP request collections for manual endpoint testing
 - `platformio.ini` - board/env config and dependencies
 
-## Notes
-
-- Default `ALLOW_ALL_FILE_CHANGES = true` in `src/main.cpp`; review before production use.
-- Consider moving credentials out of source code for shared/public deployments.


### PR DESCRIPTION
### Motivation
- Replace the minimal placeholder README with a full, actionable project guide so contributors and users can quickly understand and run the firmware.
- Document architecture, runtime capabilities, and the HTTP/BLE control surface to make maintenance and extension easier.
- Surface important operational notes (LittleFS behavior and embedded credentials) to reduce accidental misconfiguration.

### Description
- Replace `README.md` with a comprehensive guide that describes hardware/firmware architecture, controller responsibilities, and wiring referenced in `src/main.cpp`.
- Document supported capabilities (emotion playback/management, ear LED control, fan control, file management, diagnostics, BLE) and the available HTTP endpoints with links to `test/http-files/*.http` examples.
- Add setup and usage instructions for building with PlatformIO, uploading firmware and LittleFS assets, opening the serial monitor, OTA notes, dependency list, and project layout.

### Testing
- Attempted a local build with `pio run`, but the PlatformIO CLI is not available in the execution environment resulting in `pio: command not found` and no build artifacts were produced.
- The README was written and verified in-repo (file content inspected with `nl`/`sed`) and then committed to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed59ae4514832dbf620ebeded48899)