### PR TITLE
Fix mobile layout for file item action buttons

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -462,6 +462,15 @@
       gap: 12px;
     }
 
+    .file-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: nowrap;
+      flex-shrink: 0;
+      margin-top: 0;
+    }
+
     .file-item.empty {
       justify-content: center;
       color: var(--muted);
@@ -469,6 +478,8 @@
     }
 
     .file-name {
+      flex: 1 1 auto;
+      min-width: 0;
       font-weight: 600;
       word-break: break-word;
     }
@@ -498,6 +509,10 @@
 
       .slider-readout {
         text-align: left;
+      }
+
+      .file-actions {
+        flex-direction: row;
       }
     }
   </style>
@@ -1336,8 +1351,7 @@
           label.textContent = file.path;
 
           var actions = document.createElement("div");
-          actions.className = "row";
-          actions.style.marginTop = "0";
+          actions.className = "file-actions";
 
           var downloadButton = document.createElement("button");
           downloadButton.type = "button";


### PR DESCRIPTION
### Motivation
- File list items on small screens were forcing action buttons to stack vertically and narrow the filename area, making items overly wide and hard to use.

### Description
- Added a dedicated `.file-actions` container and CSS to keep action buttons in a single horizontal row and prevent wrapping (`display: inline-flex; gap: 8px; flex-wrap: nowrap; flex-shrink: 0;`).
- Updated `.file-name` to `flex: 1 1 auto; min-width: 0;` so long file paths can shrink/wrap without pushing action buttons into a new line.
- Replaced the previous `row` container used in `renderFileList` with the new `file-actions` class when building file list elements in the DOM.

### Testing
- Ran `git diff --check` which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eddc4ed714832dbf017b08cdafa67a)