### PR TITLE
Add AbstractFaceDisplay and NeopixelFaceDisplay (Neopixel matrix backend)

### DIFF
--- a/src/AbstractFaceDisplay.cpp
+++ b/src/AbstractFaceDisplay.cpp
@@ -1,0 +1,333 @@
+#include "AbstractFaceDisplay.hpp"
+
+AbstractFaceDisplay *AbstractFaceDisplay::instance_ = nullptr;
+
+AbstractFaceDisplay::AbstractFaceDisplay(int width, int height)
+    : width_(width),
+      height_(height),
+      gifFile_(),
+      activeEmotionPath_(),
+      isEmotionPlaying_(false)
+{
+  instance_ = this;
+}
+
+AbstractFaceDisplay::~AbstractFaceDisplay()
+{
+  closeEmotion();
+
+  if (instance_ == this)
+  {
+    instance_ = nullptr;
+  }
+}
+
+bool AbstractFaceDisplay::begin()
+{
+  if (!initializeDisplay())
+  {
+    return false;
+  }
+
+  showBootScreen();
+
+  gif_.begin(LITTLE_ENDIAN_PIXELS);
+  return true;
+}
+
+void AbstractFaceDisplay::playEmotion(const String &emotionPath)
+{
+  if (!isEmotionPlaying_ || emotionPath != activeEmotionPath_)
+  {
+    if (!openEmotion(emotionPath))
+    {
+      return;
+    }
+  }
+
+  clearFrame();
+
+  const int result = gif_.playFrame(true, nullptr);
+  if (result < 0)
+  {
+    Serial.printf("[E] GIF play error: %i\n", gif_.getLastError());
+    if (!restartEmotion())
+    {
+      closeEmotion();
+      Serial.printf("[E] Failed to continue GIF %s\n", emotionPath.c_str());
+      return;
+    }
+
+    clearFrame();
+    gif_.playFrame(true, nullptr);
+  }
+
+  presentFrame();
+}
+
+void AbstractFaceDisplay::GIFDrawWrapper(GIFDRAW *pDraw)
+{
+  if (instance_ != nullptr)
+  {
+    instance_->GIFDraw(pDraw);
+  }
+}
+
+void *AbstractFaceDisplay::fileOpenWrapper(const char *filename, int32_t *pFileSize)
+{
+  return instance_ != nullptr ? instance_->fileOpen(filename, pFileSize) : nullptr;
+}
+
+void AbstractFaceDisplay::fileCloseWrapper(void *pHandle)
+{
+  if (instance_ != nullptr)
+  {
+    instance_->fileClose(pHandle);
+  }
+}
+
+int32_t AbstractFaceDisplay::fileReadWrapper(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen)
+{
+  return instance_ != nullptr ? instance_->fileRead(pHandle, pBuf, iLen) : 0;
+}
+
+int32_t AbstractFaceDisplay::fileSeekWrapper(GIFFILE *pHandle, int32_t iPosition)
+{
+  return instance_ != nullptr ? instance_->fileSeek(pHandle, iPosition) : -1;
+}
+
+void AbstractFaceDisplay::GIFDraw(GIFDRAW *pDraw)
+{
+  uint8_t *s;
+  uint16_t *d, *usPalette, usTemp[320];
+  int x, y;
+
+  usPalette = pDraw->pPalette;
+  y = pDraw->iY + pDraw->y;
+
+  s = pDraw->pPixels;
+  if (pDraw->ucDisposalMethod == 2)
+  {
+    for (x = 0; x < pDraw->iWidth; x++)
+    {
+      if (s[x] == pDraw->ucTransparent)
+      {
+        s[x] = pDraw->ucBackground;
+      }
+    }
+    pDraw->ucHasTransparency = 0;
+  }
+
+  if (pDraw->ucHasTransparency)
+  {
+    uint8_t *pEnd, c, ucTransparent = pDraw->ucTransparent;
+    int iCount = 0;
+    pEnd = s + pDraw->iWidth;
+    x = 0;
+    while (x < pDraw->iWidth)
+    {
+      c = ucTransparent - 1;
+      d = usTemp;
+      while (c != ucTransparent && s < pEnd)
+      {
+        c = *s++;
+        if (c == ucTransparent)
+        {
+          s--;
+        }
+        else
+        {
+          *d++ = usPalette[c];
+          iCount++;
+        }
+      }
+      if (iCount)
+      {
+        for (int xOffset = 0; xOffset < iCount; xOffset++)
+        {
+          const int pixelX = x + xOffset + pDraw->iX;
+          if (pixelX >= 0 && pixelX < width_ && y >= 0 && y < height_)
+          {
+            drawPixel(pixelX, y, usTemp[xOffset]);
+          }
+        }
+        x += iCount;
+        iCount = 0;
+      }
+      c = ucTransparent;
+      while (c == ucTransparent && s < pEnd)
+      {
+        c = *s++;
+        if (c == ucTransparent)
+        {
+          iCount++;
+        }
+        else
+        {
+          s--;
+        }
+      }
+      if (iCount)
+      {
+        x += iCount;
+        iCount = 0;
+      }
+    }
+  }
+  else
+  {
+    s = pDraw->pPixels;
+    for (x = 0; x < pDraw->iWidth; x++)
+    {
+      const int pixelX = x + pDraw->iX;
+      if (pixelX >= 0 && pixelX < width_ && y >= 0 && y < height_)
+      {
+        drawPixel(pixelX, y, usPalette[*s]);
+      }
+      s++;
+    }
+  }
+}
+
+void *AbstractFaceDisplay::fileOpen(const char *filename, int32_t *pFileSize)
+{
+  gifFile_ = LittleFS.open(filename, FILE_READ);
+  if (!gifFile_)
+  {
+    Serial.printf("Failed to open GIF file from LittleFS: %s\n", filename);
+    *pFileSize = 0;
+    return nullptr;
+  }
+
+  *pFileSize = gifFile_.size();
+  Serial.printf("[I] Opened file: %s %d B\n", filename, gifFile_.size());
+  return &gifFile_;
+}
+
+void AbstractFaceDisplay::fileClose(void *pHandle)
+{
+  (void)pHandle;
+  if (gifFile_)
+  {
+    gifFile_.close();
+  }
+}
+
+int32_t AbstractFaceDisplay::fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen)
+{
+  if (pHandle == nullptr || !pHandle->fHandle)
+  {
+    return 0;
+  }
+
+  File *file = static_cast<File *>(pHandle->fHandle);
+  if (!(*file))
+  {
+    return 0;
+  }
+
+  int32_t bytesToRead = iLen;
+  const int32_t remaining = pHandle->iSize - pHandle->iPos;
+  if (remaining < bytesToRead)
+  {
+    bytesToRead = remaining;
+  }
+
+  if (bytesToRead <= 0)
+  {
+    return 0;
+  }
+
+  const int32_t bytesRead = file->read(pBuf, static_cast<size_t>(bytesToRead));
+  pHandle->iPos = static_cast<int32_t>(file->position());
+  return bytesRead;
+}
+
+int32_t AbstractFaceDisplay::fileSeek(GIFFILE *pHandle, int32_t iPosition)
+{
+  if (pHandle == nullptr || !pHandle->fHandle)
+  {
+    return -1;
+  }
+
+  File *file = static_cast<File *>(pHandle->fHandle);
+  if (!(*file))
+  {
+    return -1;
+  }
+
+  if (iPosition < 0)
+  {
+    iPosition = 0;
+  }
+
+  if (iPosition > pHandle->iSize)
+  {
+    iPosition = pHandle->iSize;
+  }
+
+  if (!file->seek(iPosition, SeekSet))
+  {
+    return -1;
+  }
+
+  pHandle->iPos = static_cast<int32_t>(file->position());
+  return pHandle->iPos;
+}
+
+bool AbstractFaceDisplay::openEmotion(const String &emotionPath, bool logTransition)
+{
+  if (emotionPath.isEmpty())
+  {
+    Serial.println(F("[E] Emotion path is empty"));
+    closeEmotion();
+    return false;
+  }
+
+  closeEmotion();
+
+  if (!gif_.open(emotionPath.c_str(), fileOpenWrapper, fileCloseWrapper, fileReadWrapper,
+                 fileSeekWrapper, GIFDrawWrapper))
+  {
+    Serial.printf("[E] Failed to open GIF %s\n", emotionPath.c_str());
+    return false;
+  }
+
+  activeEmotionPath_ = emotionPath;
+  isEmotionPlaying_ = true;
+
+  if (logTransition)
+  {
+    Serial.printf("[I] Playing GIF %s\n", emotionPath.c_str());
+  }
+
+  return true;
+}
+
+void AbstractFaceDisplay::closeEmotion()
+{
+  if (isEmotionPlaying_)
+  {
+    gif_.close();
+  }
+
+  if (gifFile_)
+  {
+    gifFile_.close();
+  }
+
+  isEmotionPlaying_ = false;
+  activeEmotionPath_ = "";
+}
+
+bool AbstractFaceDisplay::restartEmotion()
+{
+  if (activeEmotionPath_.isEmpty())
+  {
+    return false;
+  }
+
+  const String path = activeEmotionPath_;
+  closeEmotion();
+  return openEmotion(path, false);
+}

--- a/src/AbstractFaceDisplay.hpp
+++ b/src/AbstractFaceDisplay.hpp
@@ -1,0 +1,52 @@
+#ifndef ABSTRACT_FACE_DISPLAY_HPP
+#define ABSTRACT_FACE_DISPLAY_HPP
+
+#include <AnimatedGIF.h>
+#include <LittleFS.h>
+
+#include <Arduino.h>
+
+class AbstractFaceDisplay {
+public:
+  virtual ~AbstractFaceDisplay();
+
+  bool begin();
+  void playEmotion(const String &emotionPath);
+
+protected:
+  AbstractFaceDisplay(int width, int height);
+
+  virtual bool initializeDisplay() = 0;
+  virtual void drawPixel(int x, int y, uint16_t color565) = 0;
+  virtual void clearFrame() = 0;
+  virtual void presentFrame() = 0;
+  virtual void showBootScreen() = 0;
+
+  int width_;
+  int height_;
+
+private:
+  static AbstractFaceDisplay *instance_;
+
+  static void GIFDrawWrapper(GIFDRAW *pDraw);
+  static void *fileOpenWrapper(const char *filename, int32_t *pFileSize);
+  static void fileCloseWrapper(void *pHandle);
+  static int32_t fileReadWrapper(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen);
+  static int32_t fileSeekWrapper(GIFFILE *pHandle, int32_t iPosition);
+
+  void GIFDraw(GIFDRAW *pDraw);
+  void *fileOpen(const char *filename, int32_t *pFileSize);
+  void fileClose(void *pHandle);
+  int32_t fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen);
+  int32_t fileSeek(GIFFILE *pHandle, int32_t iPosition);
+  bool openEmotion(const String &emotionPath, bool logTransition = true);
+  void closeEmotion();
+  bool restartEmotion();
+
+  AnimatedGIF gif_;
+  File gifFile_;
+  String activeEmotionPath_;
+  bool isEmotionPlaying_;
+};
+
+#endif // ABSTRACT_FACE_DISPLAY_HPP

--- a/src/FaceDisplay.cpp
+++ b/src/FaceDisplay.cpp
@@ -1,40 +1,27 @@
 #include "FaceDisplay.hpp"
 
-FaceDisplay *FaceDisplay::instance_ = nullptr;
-
 FaceDisplay::FaceDisplay(int panelResX, int panelResY, int panelChainLength)
-    : panelResX_(panelResX),
-      panelResY_(panelResY),
+    : AbstractFaceDisplay(panelResX * panelChainLength, panelResY),
       panelChainLength_(panelChainLength),
       display_(nullptr),
-      gifFile_(),
-      activeEmotionPath_(),
-      isEmotionPlaying_(false),
       colorBlue_(0),
       colorBlack_(0)
 {
-  instance_ = this;
 }
 
 FaceDisplay::~FaceDisplay()
 {
-  closeEmotion();
-
   if (display_ != nullptr)
   {
     delete display_;
     display_ = nullptr;
   }
-
-  if (instance_ == this)
-  {
-    instance_ = nullptr;
-  }
 }
 
-bool FaceDisplay::begin()
+bool FaceDisplay::initializeDisplay()
 {
-  HUB75_I2S_CFG mxconfig(panelResX_, panelResY_, panelChainLength_);
+  const int panelResX = width_ / panelChainLength_;
+  HUB75_I2S_CFG mxconfig(panelResX, height_, panelChainLength_);
   mxconfig.gpio.e = 18;
   mxconfig.clkphase = false;
 
@@ -42,6 +29,35 @@ bool FaceDisplay::begin()
   display_->begin();
 
   initializeColors();
+  return true;
+}
+
+void FaceDisplay::drawPixel(int x, int y, uint16_t color565)
+{
+  if (display_ != nullptr)
+  {
+    display_->drawPixel(x, y, color565);
+  }
+}
+
+void FaceDisplay::clearFrame()
+{
+  if (display_ != nullptr)
+  {
+    display_->fillScreen(colorBlack_);
+  }
+}
+
+void FaceDisplay::presentFrame()
+{
+}
+
+void FaceDisplay::showBootScreen()
+{
+  if (display_ == nullptr)
+  {
+    return;
+  }
 
   display_->fillScreen(colorBlack_);
   display_->setCursor(5, 0);
@@ -50,299 +66,6 @@ bool FaceDisplay::begin()
   display_->println("ProtoFW 2.0");
   display_->setCursor(12, 10);
   display_->println("Lutra 3D");
-
-  gif_.begin(LITTLE_ENDIAN_PIXELS);
-  return true;
-}
-
-void FaceDisplay::playEmotion(const String &emotionPath)
-{
-  if (display_ == nullptr)
-  {
-    return;
-  }
-
-  if (!isEmotionPlaying_ || emotionPath != activeEmotionPath_)
-  {
-    if (!openEmotion(emotionPath))
-    {
-      return;
-    }
-  }
-
-  const int result = gif_.playFrame(true, nullptr);
-  if (result >= 0)
-  {
-    return;
-  }
-
-  Serial.printf("[E] GIF play error: %i\n", gif_.getLastError());
-  if (!restartEmotion())
-  {
-    closeEmotion();
-    Serial.printf("[E] Failed to continue GIF %s\n", emotionPath.c_str());
-    return;
-  }
-
-  gif_.playFrame(true, nullptr);
-}
-
-void FaceDisplay::GIFDrawWrapper(GIFDRAW *pDraw)
-{
-  if (instance_ != nullptr)
-  {
-    instance_->GIFDraw(pDraw);
-  }
-}
-
-void *FaceDisplay::fileOpenWrapper(const char *filename, int32_t *pFileSize)
-{
-  return instance_ != nullptr ? instance_->fileOpen(filename, pFileSize) : nullptr;
-}
-
-void FaceDisplay::fileCloseWrapper(void *pHandle)
-{
-  if (instance_ != nullptr)
-  {
-    instance_->fileClose(pHandle);
-  }
-}
-
-int32_t FaceDisplay::fileReadWrapper(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen)
-{
-  return instance_ != nullptr ? instance_->fileRead(pHandle, pBuf, iLen) : 0;
-}
-
-int32_t FaceDisplay::fileSeekWrapper(GIFFILE *pHandle, int32_t iPosition)
-{
-  return instance_ != nullptr ? instance_->fileSeek(pHandle, iPosition) : -1;
-}
-
-void FaceDisplay::GIFDraw(GIFDRAW *pDraw)
-{
-  uint8_t *s;
-  uint16_t *d, *usPalette, usTemp[320];
-  int x, y;
-
-  usPalette = pDraw->pPalette;
-  y = pDraw->iY + pDraw->y;
-
-  s = pDraw->pPixels;
-  if (pDraw->ucDisposalMethod == 2)
-  {
-    for (x = 0; x < pDraw->iWidth; x++)
-    {
-      if (s[x] == pDraw->ucTransparent)
-      {
-        s[x] = pDraw->ucBackground;
-      }
-    }
-    pDraw->ucHasTransparency = 0;
-  }
-
-  if (pDraw->ucHasTransparency)
-  {
-    uint8_t *pEnd, c, ucTransparent = pDraw->ucTransparent;
-    int iCount = 0;
-    pEnd = s + pDraw->iWidth;
-    x = 0;
-    while (x < pDraw->iWidth)
-    {
-      c = ucTransparent - 1;
-      d = usTemp;
-      while (c != ucTransparent && s < pEnd)
-      {
-        c = *s++;
-        if (c == ucTransparent)
-        {
-          s--;
-        }
-        else
-        {
-          *d++ = usPalette[c];
-          iCount++;
-        }
-      }
-      if (iCount)
-      {
-        for (int xOffset = 0; xOffset < iCount; xOffset++)
-        {
-          display_->drawPixel(x + xOffset + pDraw->iX, y, usTemp[xOffset]);
-        }
-        x += iCount;
-        iCount = 0;
-      }
-      c = ucTransparent;
-      while (c == ucTransparent && s < pEnd)
-      {
-        c = *s++;
-        if (c == ucTransparent)
-        {
-          iCount++;
-        }
-        else
-        {
-          s--;
-        }
-      }
-      if (iCount)
-      {
-        x += iCount;
-        iCount = 0;
-      }
-    }
-  }
-  else
-  {
-    s = pDraw->pPixels;
-    for (x = 0; x < pDraw->iWidth; x++)
-    {
-      display_->drawPixel(x + pDraw->iX, y, usPalette[*s++]);
-    }
-  }
-}
-
-void *FaceDisplay::fileOpen(const char *filename, int32_t *pFileSize)
-{
-  gifFile_ = LittleFS.open(filename, FILE_READ);
-  if (!gifFile_)
-  {
-    Serial.printf("Failed to open GIF file from LittleFS: %s\n", filename);
-    *pFileSize = 0;
-    return nullptr;
-  }
-
-  *pFileSize = gifFile_.size();
-  Serial.printf("[I] Opened file: %s %d B\n", filename, gifFile_.size());
-  return &gifFile_;
-}
-
-void FaceDisplay::fileClose(void *pHandle)
-{
-  (void)pHandle;
-  if (gifFile_)
-  {
-    gifFile_.close();
-  }
-}
-
-int32_t FaceDisplay::fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen)
-{
-  if (pHandle == nullptr || !pHandle->fHandle)
-  {
-    return 0;
-  }
-
-  File *file = static_cast<File *>(pHandle->fHandle);
-  if (!(*file))
-  {
-    return 0;
-  }
-
-  int32_t bytesToRead = iLen;
-  const int32_t remaining = pHandle->iSize - pHandle->iPos;
-  if (remaining < bytesToRead)
-  {
-    bytesToRead = remaining;
-  }
-
-  if (bytesToRead <= 0)
-  {
-    return 0;
-  }
-
-  const int32_t bytesRead = file->read(pBuf, static_cast<size_t>(bytesToRead));
-  pHandle->iPos = static_cast<int32_t>(file->position());
-  return bytesRead;
-}
-
-int32_t FaceDisplay::fileSeek(GIFFILE *pHandle, int32_t iPosition)
-{
-  if (pHandle == nullptr || !pHandle->fHandle)
-  {
-    return -1;
-  }
-
-  File *file = static_cast<File *>(pHandle->fHandle);
-  if (!(*file))
-  {
-    return -1;
-  }
-
-  if (iPosition < 0)
-  {
-    iPosition = 0;
-  }
-
-  if (iPosition > pHandle->iSize)
-  {
-    iPosition = pHandle->iSize;
-  }
-
-  if (!file->seek(iPosition, SeekSet))
-  {
-    return -1;
-  }
-
-  pHandle->iPos = static_cast<int32_t>(file->position());
-  return pHandle->iPos;
-}
-
-bool FaceDisplay::openEmotion(const String &emotionPath, bool logTransition)
-{
-  if (emotionPath.isEmpty())
-  {
-    Serial.println(F("[E] Emotion path is empty"));
-    closeEmotion();
-    return false;
-  }
-
-  closeEmotion();
-
-  if (!gif_.open(emotionPath.c_str(), fileOpenWrapper, fileCloseWrapper, fileReadWrapper,
-                 fileSeekWrapper, GIFDrawWrapper))
-  {
-    Serial.printf("[E] Failed to open GIF %s\n", emotionPath.c_str());
-    return false;
-  }
-
-  activeEmotionPath_ = emotionPath;
-  isEmotionPlaying_ = true;
-
-  if (logTransition)
-  {
-    Serial.printf("[I] Playing GIF %s\n", emotionPath.c_str());
-  }
-
-  return true;
-}
-
-void FaceDisplay::closeEmotion()
-{
-  if (isEmotionPlaying_)
-  {
-    gif_.close();
-  }
-
-  if (gifFile_)
-  {
-    gifFile_.close();
-  }
-
-  isEmotionPlaying_ = false;
-  activeEmotionPath_ = "";
-}
-
-bool FaceDisplay::restartEmotion()
-{
-  if (activeEmotionPath_.isEmpty())
-  {
-    return false;
-  }
-
-  const String path = activeEmotionPath_;
-  closeEmotion();
-  return openEmotion(path, false);
 }
 
 void FaceDisplay::initializeColors()

--- a/src/FaceDisplay.hpp
+++ b/src/FaceDisplay.hpp
@@ -1,48 +1,27 @@
 #ifndef FACE_DISPLAY_HPP
 #define FACE_DISPLAY_HPP
 
-#include <AnimatedGIF.h>
 #include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
-#include <LittleFS.h>
 
-#include <Arduino.h>
+#include "AbstractFaceDisplay.hpp"
 
-class FaceDisplay {
+class FaceDisplay : public AbstractFaceDisplay {
 public:
   FaceDisplay(int panelResX, int panelResY, int panelChainLength);
-  ~FaceDisplay();
+  ~FaceDisplay() override;
 
-  bool begin();
-  void playEmotion(const String &emotionPath);
+protected:
+  bool initializeDisplay() override;
+  void drawPixel(int x, int y, uint16_t color565) override;
+  void clearFrame() override;
+  void presentFrame() override;
+  void showBootScreen() override;
 
 private:
-  static FaceDisplay *instance_;
-
-  static void GIFDrawWrapper(GIFDRAW *pDraw);
-  static void *fileOpenWrapper(const char *filename, int32_t *pFileSize);
-  static void fileCloseWrapper(void *pHandle);
-  static int32_t fileReadWrapper(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen);
-  static int32_t fileSeekWrapper(GIFFILE *pHandle, int32_t iPosition);
-
-  void GIFDraw(GIFDRAW *pDraw);
-  void *fileOpen(const char *filename, int32_t *pFileSize);
-  void fileClose(void *pHandle);
-  int32_t fileRead(GIFFILE *pHandle, uint8_t *pBuf, int32_t iLen);
-  int32_t fileSeek(GIFFILE *pHandle, int32_t iPosition);
-  bool openEmotion(const String &emotionPath, bool logTransition = true);
-  void closeEmotion();
-  bool restartEmotion();
   void initializeColors();
 
-  int panelResX_;
-  int panelResY_;
   int panelChainLength_;
-
   MatrixPanel_I2S_DMA *display_;
-  AnimatedGIF gif_;
-  File gifFile_;
-  String activeEmotionPath_;
-  bool isEmotionPlaying_;
 
   uint16_t colorBlue_;
   uint16_t colorBlack_;

--- a/src/NeopixelFaceDisplay.cpp
+++ b/src/NeopixelFaceDisplay.cpp
@@ -1,0 +1,96 @@
+#include "NeopixelFaceDisplay.hpp"
+
+namespace {
+uint8_t Expand5to8(uint16_t value)
+{
+  return static_cast<uint8_t>((value * 527U + 23U) >> 6);
+}
+
+uint8_t Expand6to8(uint16_t value)
+{
+  return static_cast<uint8_t>((value * 259U + 33U) >> 6);
+}
+} // namespace
+
+NeopixelFaceDisplay::NeopixelFaceDisplay(uint16_t width, uint16_t height, uint8_t leftPin,
+                                         uint8_t rightPin)
+    : AbstractFaceDisplay(width * 2, height),
+      panelWidth_(width),
+      panelHeight_(height),
+      pixelsPerPanel_(width * height),
+      leftPin_(leftPin),
+      rightPin_(rightPin),
+      leftDisplay_(pixelsPerPanel_, leftPin_, NEO_GRB + NEO_KHZ800),
+      rightDisplay_(pixelsPerPanel_, rightPin_, NEO_GRB + NEO_KHZ800)
+{
+}
+
+NeopixelFaceDisplay::~NeopixelFaceDisplay() {}
+
+bool NeopixelFaceDisplay::initializeDisplay()
+{
+  leftDisplay_.begin();
+  rightDisplay_.begin();
+  clearFrame();
+  presentFrame();
+  return true;
+}
+
+uint16_t NeopixelFaceDisplay::mapCoordinatesToIndex(uint16_t x, uint16_t y) const
+{
+  if (x >= panelWidth_ || y >= panelHeight_)
+  {
+    return 0;
+  }
+
+  if ((y & 1U) == 0)
+  {
+    return y * panelWidth_ + x;
+  }
+
+  return y * panelWidth_ + (panelWidth_ - 1 - x);
+}
+
+void NeopixelFaceDisplay::drawPixel(int x, int y, uint16_t color565)
+{
+  if (x < 0 || y < 0 || y >= panelHeight_ || x >= width_)
+  {
+    return;
+  }
+
+  const bool isRightPanel = (x >= panelWidth_);
+  const uint16_t panelX = static_cast<uint16_t>(isRightPanel ? x - panelWidth_ : x);
+  const uint16_t index = mapCoordinatesToIndex(panelX, static_cast<uint16_t>(y));
+
+  const uint8_t red = Expand5to8((color565 >> 11) & 0x1F);
+  const uint8_t green = Expand6to8((color565 >> 5) & 0x3F);
+  const uint8_t blue = Expand5to8(color565 & 0x1F);
+  const uint32_t color = Adafruit_NeoPixel::Color(red, green, blue);
+
+  if (isRightPanel)
+  {
+    rightDisplay_.setPixelColor(index, color);
+  }
+  else
+  {
+    leftDisplay_.setPixelColor(index, color);
+  }
+}
+
+void NeopixelFaceDisplay::clearFrame()
+{
+  leftDisplay_.clear();
+  rightDisplay_.clear();
+}
+
+void NeopixelFaceDisplay::presentFrame()
+{
+  leftDisplay_.show();
+  rightDisplay_.show();
+}
+
+void NeopixelFaceDisplay::showBootScreen()
+{
+  clearFrame();
+  presentFrame();
+}

--- a/src/NeopixelFaceDisplay.hpp
+++ b/src/NeopixelFaceDisplay.hpp
@@ -1,0 +1,33 @@
+#ifndef NEOPIXEL_FACE_DISPLAY_HPP
+#define NEOPIXEL_FACE_DISPLAY_HPP
+
+#include <Adafruit_NeoPixel.h>
+
+#include "AbstractFaceDisplay.hpp"
+
+class NeopixelFaceDisplay : public AbstractFaceDisplay {
+public:
+  NeopixelFaceDisplay(uint16_t width, uint16_t height, uint8_t leftPin, uint8_t rightPin);
+  ~NeopixelFaceDisplay() override;
+
+  uint16_t mapCoordinatesToIndex(uint16_t x, uint16_t y) const;
+
+protected:
+  bool initializeDisplay() override;
+  void drawPixel(int x, int y, uint16_t color565) override;
+  void clearFrame() override;
+  void presentFrame() override;
+  void showBootScreen() override;
+
+private:
+  uint16_t panelWidth_;
+  uint16_t panelHeight_;
+  uint16_t pixelsPerPanel_;
+  uint8_t leftPin_;
+  uint8_t rightPin_;
+
+  Adafruit_NeoPixel leftDisplay_;
+  Adafruit_NeoPixel rightDisplay_;
+};
+
+#endif // NEOPIXEL_FACE_DISPLAY_HPP

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,0 +1,36 @@
+#ifndef CONFIG_HPP
+#define CONFIG_HPP
+
+#include <Arduino.h>
+
+// Wi-Fi configuration
+const char *WIFI_NAME = "Proto";
+const char *WIFI_PASS = "Test123456!";
+
+// HUB75 P3 Display configuration
+#define PANEL_RES_X 64
+#define PANEL_RES_Y 32
+#define PANEL_CHAIN 2
+
+// Neopixel matrix configuration
+// #define FACE_NEOPIXEL_PANEL_WIDTH 16 // Width of each Neopixel matrix
+// #define FACE_NEOPIXEL_PANEL_HEIGHT 16 // Height of each Neopixel matrix
+// #define FACE_NEOPIXEL_OUT_L 33 // GPIO pin for left Neopixel panel must support PWM
+// #define FACE_NEOPIXEL_OUT_R 32 // GPIO pin for right Neopixel panel must support PWM
+
+// Fan configuration
+constexpr uint8_t FAN_PWM_PIN = 32;
+constexpr uint8_t FAN_PWM_CHANNEL = 0;
+constexpr uint32_t FAN_PWM_FREQUENCY = 25000;
+constexpr uint8_t FAN_PWM_RESOLUTION = 8;
+
+// Ear LED configuration
+constexpr uint16_t LEDS_PER_DISPLAY = 32;
+constexpr uint8_t DATA_PIN_EARS = 33;
+
+constexpr uint8_t PIN_SDA = 21;
+constexpr uint8_t PIN_SCL = 22;
+
+constexpr bool ALLOW_ALL_FILE_CHANGES = true;
+
+#endif // CONFIG_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,45 +15,21 @@
 #include "WebServerManager.hpp"
 #include "BLEController.hpp"
 #include "Capabilities/CapabilityManager.hpp"
+#include "config.hpp"
 
-// Display configuration
-constexpr int PANEL_RES_X = 64;
-constexpr int PANEL_RES_Y = 32;
-constexpr int PANEL_CHAIN = 2;
-
-// Wi-Fi configuration
-const char *WIFI_NAME = "Proto";
-const char *WIFI_PASS = "Test123456!";
-
-// Fan configuration
-constexpr uint8_t FAN_PWM_PIN = 32;
-constexpr uint8_t FAN_PWM_CHANNEL = 0;
-constexpr uint32_t FAN_PWM_FREQUENCY = 25000;
-constexpr uint8_t FAN_PWM_RESOLUTION = 8;
-
-// Ear LED configuration
-constexpr uint16_t LEDS_PER_DISPLAY = 32;
-constexpr uint8_t DATA_PIN_EARS = 33;
-
-constexpr uint8_t PIN_SDA = 21;
-constexpr uint8_t PIN_SCL = 22;
-
-constexpr bool ALLOW_ALL_FILE_CHANGES = true;
-
+#if defined(FACE_NEOPIXEL_OUT_L) && defined(FACE_NEOPIXEL_OUT_R) && defined(FACE_NEOPIXEL_PANEL_WIDTH) && defined(FACE_NEOPIXEL_PANEL_HEIGHT)
+NeopixelFaceDisplay faceDisplay(FACE_NEOPIXEL_PANEL_WIDTH, FACE_NEOPIXEL_PANEL_HEIGHT, FACE_NEOPIXEL_OUT_L, FACE_NEOPIXEL_OUT_R);
+#elif defined(PANEL_RES_X) && defined(PANEL_RES_Y) && defined(PANEL_CHAIN)
+FaceDisplay faceDisplay(PANEL_RES_X, PANEL_RES_Y, PANEL_CHAIN);
+#else
+#error "Display configuration is incomplete. Please define either the Neopixel display pins and dimensions or the HUB75 panel resolution and chain length."
+#endif
 
 EmotionState emotionState;
 FanController fanController(FAN_PWM_PIN, FAN_PWM_CHANNEL, FAN_PWM_FREQUENCY, FAN_PWM_RESOLUTION);
 EarController earController(LEDS_PER_DISPLAY, DATA_PIN_EARS);
 TiltController tiltController(emotionState, PIN_SDA, PIN_SCL);
 FileManager fileManager;
-#if defined(FACE_NEOPIXEL_OUT_L) && defined(FACE_NEOPIXEL_OUT_R)
-constexpr uint8_t FACE_NEOPIXEL_PANEL_WIDTH = 16;
-constexpr uint8_t FACE_NEOPIXEL_PANEL_HEIGHT = 16;
-NeopixelFaceDisplay faceDisplay(FACE_NEOPIXEL_PANEL_WIDTH, FACE_NEOPIXEL_PANEL_HEIGHT,
-                                FACE_NEOPIXEL_OUT_L, FACE_NEOPIXEL_OUT_R);
-#else
-FaceDisplay faceDisplay(PANEL_RES_X, PANEL_RES_Y, PANEL_CHAIN);
-#endif
 SettingsStorage settingsStorage(emotionState, fanController, earController);
 void onSettingsChanged()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,9 @@
 #ifdef MAIN
 #include <Arduino.h>
 
+#include "AbstractFaceDisplay.hpp"
 #include "FaceDisplay.hpp"
+#include "NeopixelFaceDisplay.hpp"
 #include "FileManager.hpp"
 #include "DisplayManager.hpp"
 #include "EarController.hpp"
@@ -44,7 +46,14 @@ FanController fanController(FAN_PWM_PIN, FAN_PWM_CHANNEL, FAN_PWM_FREQUENCY, FAN
 EarController earController(LEDS_PER_DISPLAY, DATA_PIN_EARS);
 TiltController tiltController(emotionState, PIN_SDA, PIN_SCL);
 FileManager fileManager;
+#if defined(FACE_NEOPIXEL_OUT_L) && defined(FACE_NEOPIXEL_OUT_R)
+constexpr uint8_t FACE_NEOPIXEL_PANEL_WIDTH = 16;
+constexpr uint8_t FACE_NEOPIXEL_PANEL_HEIGHT = 16;
+NeopixelFaceDisplay faceDisplay(FACE_NEOPIXEL_PANEL_WIDTH, FACE_NEOPIXEL_PANEL_HEIGHT,
+                                FACE_NEOPIXEL_OUT_L, FACE_NEOPIXEL_OUT_R);
+#else
 FaceDisplay faceDisplay(PANEL_RES_X, PANEL_RES_Y, PANEL_CHAIN);
+#endif
 SettingsStorage settingsStorage(emotionState, fanController, earController);
 void onSettingsChanged()
 {


### PR DESCRIPTION
### Motivation
- Provide an alternative face display backend for hardware without HUB75 panels by supporting two 16x16 NeoPixel matrices driven from `FACE_NEOPIXEL_OUT_L`/`FACE_NEOPIXEL_OUT_R` pins.
- Reuse the existing GIF playback and LittleFS file handling logic while allowing multiple concrete display implementations to be swapped transparently.

### Description
- Introduced `AbstractFaceDisplay` to centralize GIF decoding, LittleFS file callbacks, playback control (`begin()`/`playEmotion()`), and the GIF draw callback plumbing so concrete displays only implement pixel I/O and frame presentation (`src/AbstractFaceDisplay.*`).
- Refactored the original HUB75 implementation into `FaceDisplay` inheriting from `AbstractFaceDisplay`, moving HUB75-specific init and pixel writes into `src/FaceDisplay.*` while preserving the existing boot text and color setup.
- Added `NeopixelFaceDisplay` implementing an interchangeable backend that accepts `width`, `height`, `leftPin`, and `rightPin`, converts GIF RGB565 pixels to RGB888, maps X/Y to NeoPixel indices with serpentine addressing via `mapCoordinatesToIndex()`, and drives left/right `Adafruit_NeoPixel` instances (`src/NeopixelFaceDisplay.*`).
- Updated `src/main.cpp` to instantiate `NeopixelFaceDisplay` automatically when `FACE_NEOPIXEL_OUT_L` and `FACE_NEOPIXEL_OUT_R` are defined, otherwise fall back to `FaceDisplay`, leaving the rest of the system unchanged.

### Testing
- Attempted to build with `pio run` inside the container, but the command failed because `pio` is not installed (`/bin/bash: pio: command not found`).
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee26862b48832daff20155bd90bf0d)