### PR TITLE
Add NeopixelFaceDisplay as alternative face output

### DIFF
--- a/src/FaceDisplay/GifFaceDisplay.cpp
+++ b/src/FaceDisplay/GifFaceDisplay.cpp
@@ -45,6 +45,7 @@ void GifFaceDisplay::playEmotion(const String &emotionPath)
   const int result = gif_.playFrame(true, nullptr);
   if (result >= 0)
   {
+    afterFrameRendered();
     return;
   }
 
@@ -57,6 +58,11 @@ void GifFaceDisplay::playEmotion(const String &emotionPath)
   }
 
   gif_.playFrame(true, nullptr);
+  afterFrameRendered();
+}
+
+void GifFaceDisplay::afterFrameRendered()
+{
 }
 
 void GifFaceDisplay::GIFDrawWrapper(GIFDRAW *pDraw)

--- a/src/FaceDisplay/GifFaceDisplay.hpp
+++ b/src/FaceDisplay/GifFaceDisplay.hpp
@@ -21,6 +21,7 @@ public:
   GifFaceDisplay();
 
   virtual void drawPixel(int x, int y, Color color) = 0;
+  virtual void afterFrameRendered();
 
   bool initGif();
 

--- a/src/FaceDisplay/NeopixelFaceDisplay.cpp
+++ b/src/FaceDisplay/NeopixelFaceDisplay.cpp
@@ -1,0 +1,99 @@
+#include "NeopixelFaceDisplay.hpp"
+
+NeopixelFaceDisplay::NeopixelFaceDisplay(uint8_t leftPin, uint8_t rightPin, uint16_t panelWidth, uint16_t panelHeight)
+    : GifFaceDisplay(),
+      leftPin_(leftPin),
+      rightPin_(rightPin),
+      panelWidth_(panelWidth),
+      panelHeight_(panelHeight),
+      pixelCountPerPanel_(panelWidth * panelHeight),
+      leftPanel_(pixelCountPerPanel_, leftPin, NEO_GRB + NEO_KHZ800),
+      rightPanel_(pixelCountPerPanel_, rightPin, NEO_GRB + NEO_KHZ800),
+      initialized_(false)
+{
+}
+
+NeopixelFaceDisplay::~NeopixelFaceDisplay()
+{
+  closeEmotion();
+}
+
+bool NeopixelFaceDisplay::begin()
+{
+  Serial.println("[I] Initializing NeopixelFaceDisplay...");
+
+  if (panelWidth_ == 0 || panelHeight_ == 0)
+  {
+    Serial.println("[E] Invalid neopixel panel dimensions.");
+    return false;
+  }
+
+  leftPanel_.begin();
+  rightPanel_.begin();
+
+  leftPanel_.clear();
+  rightPanel_.clear();
+  leftPanel_.show();
+  rightPanel_.show();
+
+  initialized_ = true;
+  return initGif();
+}
+
+bool NeopixelFaceDisplay::displayReady() const
+{
+  return initialized_;
+}
+
+void NeopixelFaceDisplay::drawPixel(int x, int y, Color color)
+{
+  if (!initialized_ || x < 0 || y < 0)
+  {
+    return;
+  }
+
+  const uint16_t panelX = static_cast<uint16_t>(x);
+  const uint16_t panelY = static_cast<uint16_t>(y);
+
+  if (panelY >= panelHeight_)
+  {
+    return;
+  }
+
+  const uint32_t pixelColor = Adafruit_NeoPixel::Color(color.getRed(), color.getGreen(), color.getBlue());
+
+  if (panelX < panelWidth_)
+  {
+    leftPanel_.setPixelColor(getPixelIndex(panelX, panelY), pixelColor);
+    return;
+  }
+
+  const uint16_t rightX = panelX - panelWidth_;
+  if (rightX < panelWidth_)
+  {
+    rightPanel_.setPixelColor(getPixelIndex(rightX, panelY), pixelColor);
+  }
+}
+
+void NeopixelFaceDisplay::afterFrameRendered()
+{
+  if (!initialized_)
+  {
+    return;
+  }
+
+  leftPanel_.show();
+  rightPanel_.show();
+}
+
+uint16_t NeopixelFaceDisplay::getPixelIndex(uint16_t x, uint16_t y) const
+{
+  const uint16_t rowOffset = y * panelWidth_;
+
+  if ((y & 1U) == 0)
+  {
+    return rowOffset + x;
+  }
+
+  return rowOffset + (panelWidth_ - 1U - x);
+}

--- a/src/FaceDisplay/NeopixelFaceDisplay.hpp
+++ b/src/FaceDisplay/NeopixelFaceDisplay.hpp
@@ -1,0 +1,36 @@
+#ifndef NEOPIXELFACEDISPLAY_HPP
+#define NEOPIXELFACEDISPLAY_HPP
+
+#include <Adafruit_NeoPixel.h>
+
+#include "GifFaceDisplay.hpp"
+
+class NeopixelFaceDisplay : public GifFaceDisplay
+{
+public:
+  NeopixelFaceDisplay(uint8_t leftPin, uint8_t rightPin, uint16_t panelWidth, uint16_t panelHeight);
+  ~NeopixelFaceDisplay() override;
+
+  bool begin() override;
+  bool displayReady() const override;
+  void drawPixel(int x, int y, Color color) override;
+
+protected:
+  void afterFrameRendered() override;
+
+private:
+  uint16_t getPixelIndex(uint16_t x, uint16_t y) const;
+
+  uint8_t leftPin_;
+  uint8_t rightPin_;
+  uint16_t panelWidth_;
+  uint16_t panelHeight_;
+  uint16_t pixelCountPerPanel_;
+
+  Adafruit_NeoPixel leftPanel_;
+  Adafruit_NeoPixel rightPanel_;
+
+  bool initialized_;
+};
+
+#endif // NEOPIXELFACEDISPLAY_HPP

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -13,10 +13,11 @@ const char *WIFI_PASS = "Test123456!";
 #define PANEL_CHAIN 2
 
 // Neopixel matrix configuration
-// #define FACE_NEOPIXEL_PANEL_WIDTH 16 // Width of each Neopixel matrix
-// #define FACE_NEOPIXEL_PANEL_HEIGHT 16 // Height of each Neopixel matrix
-// #define FACE_NEOPIXEL_OUT_L 33 // GPIO pin for left Neopixel panel must support PWM
-// #define FACE_NEOPIXEL_OUT_R 32 // GPIO pin for right Neopixel panel must support PWM
+// Uncomment to use two Neopixel face panels instead of HUB75.
+// #define FACE_NEOPIXEL_PANEL_WIDTH 16 // Width of each Neopixel matrix panel
+// #define FACE_NEOPIXEL_PANEL_HEIGHT 16 // Height of each Neopixel matrix panel
+// #define FACE_NEOPIXEL_OUT_L 33 // GPIO pin for left Neopixel matrix
+// #define FACE_NEOPIXEL_OUT_R 32 // GPIO pin for right Neopixel matrix
 
 // Fan configuration
 constexpr uint8_t FAN_PWM_PIN = 32;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,11 @@
 #ifdef MAIN
 #include <Arduino.h>
 
+#if defined(FACE_NEOPIXEL_OUT_L) && defined(FACE_NEOPIXEL_OUT_R) && defined(FACE_NEOPIXEL_PANEL_WIDTH) && defined(FACE_NEOPIXEL_PANEL_HEIGHT)
+#include "FaceDisplay/NeopixelFaceDisplay.hpp"
+#else
 #include "FaceDisplay/P3MatrixFaceDisplay.hpp"
+#endif
 #include "FileManager.hpp"
 #include "DisplayManager.hpp"
 #include "EarController.hpp"
@@ -21,7 +25,11 @@ FanController fanController(FAN_PWM_PIN, FAN_PWM_CHANNEL, FAN_PWM_FREQUENCY, FAN
 EarController earController(LEDS_PER_DISPLAY, DATA_PIN_EARS);
 TiltController tiltController(emotionState, PIN_SDA, PIN_SCL);
 FileManager fileManager;
+#if defined(FACE_NEOPIXEL_OUT_L) && defined(FACE_NEOPIXEL_OUT_R) && defined(FACE_NEOPIXEL_PANEL_WIDTH) && defined(FACE_NEOPIXEL_PANEL_HEIGHT)
+NeopixelFaceDisplay faceDisplay(FACE_NEOPIXEL_OUT_L, FACE_NEOPIXEL_OUT_R, FACE_NEOPIXEL_PANEL_WIDTH, FACE_NEOPIXEL_PANEL_HEIGHT);
+#else
 P3MatrixFaceDisplay faceDisplay(PANEL_RES_X, PANEL_RES_Y, PANEL_CHAIN);
+#endif
 SettingsStorage settingsStorage(emotionState, fanController, earController);
 void onSettingsChanged()
 {


### PR DESCRIPTION
### Motivation
- Provide an alternative face output for hardware that lacks a HUB75 P3 panel but has `FACE_NEOPIXEL_OUT_L` / `FACE_NEOPIXEL_OUT_R` pins to drive two NeoPixel matrices.  
- Allow configurable panel width/height so different Neopixel matrix sizes (e.g. 16x16) can be supported.  

### Description
- Add `NeopixelFaceDisplay` (`src/FaceDisplay/NeopixelFaceDisplay.hpp/.cpp`) which extends `GifFaceDisplay`, initializes two `Adafruit_NeoPixel` panels, writes decoded GIF pixels into the appropriate left/right panel buffer, and calls `show()` after each GIF frame.  
- Implement `getPixelIndex(x, y)` in `NeopixelFaceDisplay` to map X/Y coordinates to a linear NeoPixel index using serpentine row addressing.  
- Add a frame hook `afterFrameRendered()` to `GifFaceDisplay` and invoke it after each successful `gif_.playFrame(...)` so buffered displays (NeoPixel) can flush frames.  
- Update `main.cpp` to select `NeopixelFaceDisplay` at compile time when `FACE_NEOPIXEL_OUT_L`, `FACE_NEOPIXEL_OUT_R`, `FACE_NEOPIXEL_PANEL_WIDTH`, and `FACE_NEOPIXEL_PANEL_HEIGHT` are defined, otherwise retain the existing `P3MatrixFaceDisplay`, and clarify NeoPixel-related configuration comments in `src/config.hpp`.  

### Testing
- Attempted an automated build with `pio run`, but the `pio` command is not available in the current environment so a build could not be executed (failure).  
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9c2236f4832da0e83fa8b4162751)