### PR TITLE
Decorate README with icons and tables for modules and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,128 @@
-# Protogen firmware
-Project is a firmware for **ESP32-based Protogens**. It is intended to be modular and extensible, and can be controlled over a **Web UI**, **Bluetooth remote**, or **REST API**.
+# 🤖 Protogen firmware
+
+Project is firmware for **ESP32-based Protogens**. It is intended to be modular and extensible, and can be controlled over a **Web UI**, **Bluetooth remote**, or **REST API**.
 
 ![Electronics photo](/images/protogen-insides.png)
 ![UI screenshots](/images/UI.png)
 
-## What the UI provides
+## 🖥️ What the UI provides
 
 The built-in web interface (served from `data/`) gives a quick control surface for:
-- switching the active emotion/animation,
-- configuring complex emotions that combine face-display animation with ear LED color/gradient profiles,
-- adjusting ear LED brightness,
-- controlling fan speed,
-- viewing basic device status and diagnostics,
-- managing files/emotion assets without reflashing firmware.
+
+- 🎭 switching the active emotion/animation,
+- 🧩 configuring complex emotions that combine face-display animation with ear LED color/gradient profiles,
+- 💡 adjusting ear LED brightness,
+- 🌬️ controlling fan speed,
+- 📊 viewing basic device status and diagnostics,
+- 📁 managing files/emotion assets without reflashing firmware.
 
 The same functionality is also exposed by HTTP endpoints for automation and external apps.
 
-## Capabilities
+## ✨ Capabilities
 
-### Emotion playback and management
-- Load and play animation files from LittleFS.
-- Query and set the active emotion.
-- Create/update/delete emotion definitions (including ear color/gradient metadata).
+### 🎭 Emotion playback and management
 
-### Ear LED controls
-- Read current ear state.
-- Set brightness as percent or raw 0-255 value.
+- ▶️ Load and play animation files from LittleFS.
+- 🔍 Query and set the active emotion.
+- 📝 Create/update/delete emotion definitions (including ear color/gradient metadata).
 
-### Fan controls
-- Read current duty cycle.
-- Set duty cycle over HTTP endpoint.
+### 💡 Ear LED controls
 
-### File management
-- Upload animation files.
-- List files on flash storage.
-- View partition usage.
-- Read/edit/rename/delete files.
+- 👂 Read current ear state.
+- 🔆 Set brightness as percent or raw 0-255 value.
 
-### System and diagnostics
-- Heap usage endpoint.
-- Gyro/tilt endpoint.
-- Static content hosting from `data/`.
+### 🌬️ Fan controls
 
-### BLE remote control
-- Query available emotions/capabilities.
-- Switch emotion.
-- Trigger named capabilities (brightness up/down, fan speed up/down).
+- 📈 Read current duty cycle.
+- 🎚️ Set duty cycle over HTTP endpoint.
 
-## Hardware/firmware architecture
+### 📁 File management
+
+- ⬆️ Upload animation files.
+- 🗂️ List files on flash storage.
+- 💾 View partition usage.
+- ✏️ Read/edit/rename/delete files.
+
+### 🩺 System and diagnostics
+
+- 🧠 Heap usage endpoint.
+- 🧭 Gyro/tilt endpoint.
+- 🌐 Static content hosting from `data/`.
+
+### 📡 BLE remote control
+
+- 📋 Query available emotions/capabilities.
+- 🔁 Switch emotion.
+- ⚡ Trigger named capabilities (brightness up/down, fan speed up/down).
+
+## 🧱 Hardware/firmware architecture
 
 The firmware composes several controllers and managers:
-- `FaceDisplay` renders animation files to a chained 64x32 HUB75 matrix setup.
-- `EarController` drives ear LEDs (NeoPixel-compatible strip/ring).
-- `FanController` controls fan speed through PWM.
-- `TiltController` reads motion/tilt data over I2C.
-- `WebServerManager` serves the API and static web assets over Wi‑Fi AP mode.
-- `BLEController` exposes a BLE service/characteristic for remote commands.
-- `SettingsStorage` persists runtime-adjustable settings.
+
+| Icon | Module | Responsibility |
+| --- | --- | --- |
+| 🖼️ | `FaceDisplay` | Renders animation files to a chained 64x32 HUB75 matrix setup. |
+| 👂 | `EarController` | Drives ear LEDs (NeoPixel-compatible strip/ring). |
+| 🌬️ | `FanController` | Controls fan speed through PWM. |
+| 🧭 | `TiltController` | Reads motion/tilt data over I2C. |
+| 🌐 | `WebServerManager` | Serves the API and static web assets over Wi‑Fi AP mode. |
+| 📡 | `BLEController` | Exposes a BLE service/characteristic for remote commands. |
+| 💾 | `SettingsStorage` | Persists runtime-adjustable settings. |
 
 See `src/main.cpp` for wiring and startup order.
 
-## Web/API endpoints
+## 🔌 Web/API endpoints
 
 Base URL (default AP): `http://192.168.4.1`
 
-- `GET /heap`
-- `GET /gyro`
-- `GET /emotions`
-- `GET|POST|PUT|DELETE /emotion`
-- `PUT /emotion/current`
-- `GET|PUT /fan`
-- `GET|PUT /ears`
-- `GET /capabilities`
-- `GET /files`
-- `GET /files-info`
-- `GET|POST|PUT|DELETE /file`
+| Icon | Method(s) | Endpoint | Purpose |
+| --- | --- | --- | --- |
+| 🧠 | `GET` | `/heap` | Report current heap usage for diagnostics. |
+| 🧭 | `GET` | `/gyro` | Report tilt/gyro data from the motion controller. |
+| 🎭 | `GET` | `/emotions` | List available emotion definitions. |
+| 🎭 | `GET` / `POST` / `PUT` / `DELETE` | `/emotion` | Read, create, update, or delete emotion definitions. |
+| 🔁 | `PUT` | `/emotion/current` | Switch the active emotion. |
+| 🌬️ | `GET` / `PUT` | `/fan` | Read or update fan duty cycle. |
+| 💡 | `GET` / `PUT` | `/ears` | Read or update ear LED state and brightness. |
+| ⚡ | `GET` | `/capabilities` | List remote-triggerable capabilities. |
+| 🗂️ | `GET` | `/files` | List files stored on flash. |
+| 💾 | `GET` | `/files-info` | Show filesystem/partition usage. |
+| 📄 | `GET` / `POST` / `PUT` / `DELETE` | `/file` | Read, upload, edit/rename, or delete a file. |
 
 Ready-to-run API samples are in `test/http-files/*.http`.
 
-## Tools and dependencies
+## 🛠️ Tools and dependencies
 
-- Build: [PlatformIO](https://platformio.org/) (Arduino framework, `espressif32`).
-- Core libs: `ESPAsyncWebServer`, `AsyncTCP`, `ElegantOTA`, `NimBLE-Arduino`, `ArduinoJson`, `ESP32-HUB75-MatrixPanel-DMA`, `AnimatedGIF`, `MPU6050_tockn`, `Adafruit_NeoPixel`, `Adafruit GFX`, `Adafruit SSD1306`, `esp32-sh1106-oled`.
-- Exact versions/sources: `platformio.ini`.
+- 🏗️ Build: [PlatformIO](https://platformio.org/) (Arduino framework, `espressif32`).
+- 📚 Core libs: `ESPAsyncWebServer`, `AsyncTCP`, `ElegantOTA`, `NimBLE-Arduino`, `ArduinoJson`, `ESP32-HUB75-MatrixPanel-DMA`, `AnimatedGIF`, `MPU6050_tockn`, `Adafruit_NeoPixel`, `Adafruit GFX`, `Adafruit SSD1306`, `esp32-sh1106-oled`.
+- 📌 Exact versions/sources: `platformio.ini`.
 
-## Setup
+## 🚀 Setup
 
-1. Install PlatformIO (VS Code extension or CLI).
-2. Clone and enter the repo:
+1. 📦 Install PlatformIO (VS Code extension or CLI).
+2. ⬇️ Clone and enter the repo:
    ```bash
    git clone <your-fork-or-repo-url>
    cd protogen-esp32
    ```
-3. Optional: edit `WIFI_NAME` / `WIFI_PASS` in `src/main.cpp`.
-4. Build + flash + filesystem:
+3. 📶 Optional: edit `WIFI_NAME` / `WIFI_PASS` in `src/main.cpp`.
+4. 🔨 Build + flash + filesystem:
    ```bash
    pio run
    pio run -t upload
    pio run -t uploadfs
    ```
-5. Monitor serial output:
+5. 🔎 Monitor serial output:
    ```bash
    pio device monitor -b 115200
    ```
-6. Connect to the AP and open `http://192.168.4.1`.
+6. 🌐 Connect to the AP and open `http://192.168.4.1`.
 
-## Project layout
+## 🗺️ Project layout
 
-- `src/` - firmware modules (controllers, endpoints, models, capabilities)
-- `data/` - static web assets and animation files copied to LittleFS
-- `test/http-files/` - HTTP request collections for manual endpoint testing
-- `platformio.ini` - board/env config and dependencies
+| Path | Purpose |
+| --- | --- |
+| `src/` | Firmware modules (controllers, endpoints, models, capabilities). |
+| `data/` | Static web assets and animation files copied to LittleFS. |
+| `test/http-files/` | HTTP request collections for manual endpoint testing. |
+| `platformio.ini` | Board/env config and dependencies. |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🤖 Protogen firmware
+# Protogen firmware
 
 Project is firmware for **ESP32-based Protogens**. It is intended to be modular and extensible, and can be controlled over a **Web UI**, **Bluetooth remote**, or **REST API**.
 
@@ -10,7 +10,7 @@ Project is firmware for **ESP32-based Protogens**. It is intended to be modular 
 The built-in web interface (served from `data/`) gives a quick control surface for:
 
 - 🎭 switching the active emotion/animation,
-- 🧩 configuring complex emotions that combine face-display animation with ear LED color/gradient profiles,
+- 🎨 configuring complex emotions that combine face-display animation with ear LED color/gradient profiles,
 - 💡 adjusting ear LED brightness,
 - 🌬️ controlling fan speed,
 - 📊 viewing basic device status and diagnostics,
@@ -22,52 +22,52 @@ The same functionality is also exposed by HTTP endpoints for automation and exte
 
 ### 🎭 Emotion playback and management
 
-- ▶️ Load and play animation files from LittleFS.
-- 🔍 Query and set the active emotion.
-- 📝 Create/update/delete emotion definitions (including ear color/gradient metadata).
+- Load and play animation files from LittleFS.
+- Query and set the active emotion.
+- Create/update/delete emotion definitions (including ear color/gradient metadata).
 
 ### 💡 Ear LED controls
 
-- 👂 Read current ear state.
-- 🔆 Set brightness as percent or raw 0-255 value.
+- Read current ear state.
+- Set brightness as percent or raw 0-255 value.
 
 ### 🌬️ Fan controls
 
-- 📈 Read current duty cycle.
-- 🎚️ Set duty cycle over HTTP endpoint.
+- Read current duty cycle.
+- Set duty cycle over HTTP endpoint.
 
 ### 📁 File management
 
-- ⬆️ Upload animation files.
-- 🗂️ List files on flash storage.
-- 💾 View partition usage.
-- ✏️ Read/edit/rename/delete files.
+- Upload animation files.
+- List files on flash storage.
+- View partition usage.
+- Read/edit/rename/delete files.
 
 ### 🩺 System and diagnostics
 
-- 🧠 Heap usage endpoint.
-- 🧭 Gyro/tilt endpoint.
-- 🌐 Static content hosting from `data/`.
+- Heap usage endpoint.
+- Gyro/tilt endpoint.
+- Static content hosting from `data/`.
 
 ### 📡 BLE remote control
 
-- 📋 Query available emotions/capabilities.
-- 🔁 Switch emotion.
-- ⚡ Trigger named capabilities (brightness up/down, fan speed up/down).
+- Query available emotions/capabilities.
+- Switch emotion.
+- Trigger named capabilities (brightness up/down, fan speed up/down).
 
 ## 🧱 Hardware/firmware architecture
 
 The firmware composes several controllers and managers:
 
-| Icon | Module | Responsibility |
-| --- | --- | --- |
-| 🖼️ | `FaceDisplay` | Renders animation files to a chained 64x32 HUB75 matrix setup. |
-| 👂 | `EarController` | Drives ear LEDs (NeoPixel-compatible strip/ring). |
-| 🌬️ | `FanController` | Controls fan speed through PWM. |
-| 🧭 | `TiltController` | Reads motion/tilt data over I2C. |
-| 🌐 | `WebServerManager` | Serves the API and static web assets over Wi‑Fi AP mode. |
-| 📡 | `BLEController` | Exposes a BLE service/characteristic for remote commands. |
-| 💾 | `SettingsStorage` | Persists runtime-adjustable settings. |
+| Module | Responsibility |
+| --- | --- |
+| `FaceDisplay` | Renders animation files to a chained 64x32 HUB75 matrix setup. |
+| `EarController` | Drives ear LEDs (NeoPixel-compatible strip/ring). |
+| `FanController` | Controls fan speed through PWM. |
+| `TiltController` | Reads motion/tilt data over I2C. |
+| `WebServerManager` | Serves the API and static web assets over Wi‑Fi AP mode. |
+| `BLEController` | Exposes a BLE service/characteristic for remote commands. |
+| `SettingsStorage` | Persists runtime-adjustable settings. |
 
 See `src/main.cpp` for wiring and startup order.
 
@@ -75,48 +75,48 @@ See `src/main.cpp` for wiring and startup order.
 
 Base URL (default AP): `http://192.168.4.1`
 
-| Icon | Method(s) | Endpoint | Purpose |
-| --- | --- | --- | --- |
-| 🧠 | `GET` | `/heap` | Report current heap usage for diagnostics. |
-| 🧭 | `GET` | `/gyro` | Report tilt/gyro data from the motion controller. |
-| 🎭 | `GET` | `/emotions` | List available emotion definitions. |
-| 🎭 | `GET` / `POST` / `PUT` / `DELETE` | `/emotion` | Read, create, update, or delete emotion definitions. |
-| 🔁 | `PUT` | `/emotion/current` | Switch the active emotion. |
-| 🌬️ | `GET` / `PUT` | `/fan` | Read or update fan duty cycle. |
-| 💡 | `GET` / `PUT` | `/ears` | Read or update ear LED state and brightness. |
-| ⚡ | `GET` | `/capabilities` | List remote-triggerable capabilities. |
-| 🗂️ | `GET` | `/files` | List files stored on flash. |
-| 💾 | `GET` | `/files-info` | Show filesystem/partition usage. |
-| 📄 | `GET` / `POST` / `PUT` / `DELETE` | `/file` | Read, upload, edit/rename, or delete a file. |
+| Method(s) | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/heap` | Report current heap usage for diagnostics. |
+| `GET` | `/gyro` | Report tilt/gyro data from the motion controller. |
+| `GET` | `/emotions` | List available emotion definitions. |
+| `GET` / `POST` / `PUT` / `DELETE` | `/emotion` | Read, create, update, or delete emotion definitions. |
+| `PUT` | `/emotion/current` | Switch the active emotion. |
+| `GET` / `PUT` | `/fan` | Read or update fan duty cycle. |
+| `GET` / `PUT` | `/ears` | Read or update ear LED state and brightness. |
+| `GET` | `/capabilities` | List remote-triggerable capabilities. |
+| `GET` | `/files` | List files stored on flash. |
+| `GET` | `/files-info` | Show filesystem/partition usage. |
+| `GET` / `POST` / `PUT` / `DELETE` | `/file` | Read, upload, edit/rename, or delete a file. |
 
 Ready-to-run API samples are in `test/http-files/*.http`.
 
 ## 🛠️ Tools and dependencies
 
-- 🏗️ Build: [PlatformIO](https://platformio.org/) (Arduino framework, `espressif32`).
-- 📚 Core libs: `ESPAsyncWebServer`, `AsyncTCP`, `ElegantOTA`, `NimBLE-Arduino`, `ArduinoJson`, `ESP32-HUB75-MatrixPanel-DMA`, `AnimatedGIF`, `MPU6050_tockn`, `Adafruit_NeoPixel`, `Adafruit GFX`, `Adafruit SSD1306`, `esp32-sh1106-oled`.
-- 📌 Exact versions/sources: `platformio.ini`.
+- Build: [PlatformIO](https://platformio.org/) (Arduino framework, `espressif32`).
+- Core libs: `ESPAsyncWebServer`, `AsyncTCP`, `ElegantOTA`, `NimBLE-Arduino`, `ArduinoJson`, `ESP32-HUB75-MatrixPanel-DMA`, `AnimatedGIF`, `MPU6050_tockn`, `Adafruit_NeoPixel`, `Adafruit GFX`, `Adafruit SSD1306`, `esp32-sh1106-oled`.
+- Exact versions/sources: `platformio.ini`.
 
 ## 🚀 Setup
 
-1. 📦 Install PlatformIO (VS Code extension or CLI).
-2. ⬇️ Clone and enter the repo:
+1. Install PlatformIO (VS Code extension or CLI).
+2. Clone and enter the repo:
    ```bash
    git clone <your-fork-or-repo-url>
    cd protogen-esp32
    ```
-3. 📶 Optional: edit `WIFI_NAME` / `WIFI_PASS` in `src/main.cpp`.
-4. 🔨 Build + flash + filesystem:
+3. Optional: edit `WIFI_NAME` / `WIFI_PASS` in `src/main.cpp`.
+4. Build + flash + filesystem:
    ```bash
    pio run
    pio run -t upload
    pio run -t uploadfs
    ```
-5. 🔎 Monitor serial output:
+5. Monitor serial output:
    ```bash
    pio device monitor -b 115200
    ```
-6. 🌐 Connect to the AP and open `http://192.168.4.1`.
+6. Connect to the AP and open `http://192.168.4.1`.
 
 ## 🗺️ Project layout
 


### PR DESCRIPTION
### Motivation
- Improve README readability and make API and module information easier to scan by adding semantic icons and structured tables. 
- Provide a concise reference for Web/API endpoints and firmware modules for both developers and external integrators.

### Description
- Added semantic emoji icons to the title, section headings, capability lists, setup steps, and other descriptive lists for clearer visual scanning. 
- Converted the firmware module list into a Markdown table mapping icons, module names, and responsibilities. 
- Converted the Web/API endpoint list into a Markdown table showing icon, HTTP method(s), endpoint, and purpose. 
- Converted the project layout into a concise table and made minor wording/formatting adjustments to the README.

### Testing
- Ran `git diff --check` to validate the diff and whitespace issues, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006e00244c832d95eeeae81617e9c1)