### PR TITLE
Add INA226 SystemPowerController, endpoint and dashboard/display integration

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -683,6 +683,15 @@
       </div>
       <div id="gyroStatus" class="status"></div>
     </section>
+
+    <section>
+      <h2>System Power</h2>
+      <div class="display-row">
+        <div class="value-display">Value: <span id="systemPowerValue" class="value">--</span></div>
+        <button id="systemPowerRefresh" class="icon-button" type="button" aria-label="Refresh system power" title="Refresh">↻</button>
+      </div>
+      <div id="systemPowerStatus" class="status"></div>
+    </section>
     <p>Lutra 3D, 2025</p>
   </main>
 
@@ -767,6 +776,8 @@
       var heapStatus = $("heapStatus");
       var gyroValue = $("gyroValue");
       var gyroStatus = $("gyroStatus");
+      var systemPowerValue = $("systemPowerValue");
+      var systemPowerStatus = $("systemPowerStatus");
 
       var allFiles = [];
       var animationFiles = [];
@@ -1304,6 +1315,16 @@
         });
       }
 
+      function refreshSystemPower() {
+        fetchText("/system-power").then(function (text) {
+          setText(systemPowerValue, text);
+          setText(systemPowerStatus, "");
+        }).catch(function (error) {
+          setText(systemPowerValue, "--");
+          setText(systemPowerStatus, "Error: " + error.message);
+        });
+      }
+
       uploadForm.addEventListener("submit", function (event) {
         event.preventDefault();
         if (!fileInput.files.length) {
@@ -1607,6 +1628,7 @@
       $("earApply").addEventListener("click", applyEars);
       $("heapRefresh").addEventListener("click", refreshHeap);
       $("gyroRefresh").addEventListener("click", refreshGyro);
+      $("systemPowerRefresh").addEventListener("click", refreshSystemPower);
 
       hideEmotionForm();
       Promise.all([
@@ -1621,6 +1643,7 @@
       refreshEars();
       refreshHeap();
       refreshGyro();
+      refreshSystemPower();
     })();
   </script>
 </body>

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -38,12 +38,14 @@ const uint8_t BRIGHTNESS_ICON_12X12[] PROGMEM = {
 DisplayManager::DisplayManager(uint8_t sdaPin, uint8_t sclPin,
                                EmotionState &emotionState,
                                FanController &fanController,
-                               LedBrightnessController &brightnessController)
+                               LedBrightnessController &brightnessController,
+                               SystemPowerController &systemPowerController)
     : sdaPin_(sdaPin),
       sclPin_(sclPin),
       emotionState_(emotionState),
       fanController_(fanController),
       brightnessController_(brightnessController),
+      systemPowerController_(systemPowerController),
       display_() {}
 
 void DisplayManager::begin() {
@@ -75,8 +77,14 @@ void DisplayManager::renderStatus() {
   DrawIconLine(FAN_ICON_12X12, 18, formatFanInfo());
   DrawIconLine(BRIGHTNESS_ICON_12X12, 18+lineHeight, formatEarInfo());
 
+  uint8_t statusLine = 2;
+  if (systemPowerController_.isEnabled()) {
+    DrawIconLine(BRIGHTNESS_ICON_12X12, 18 + statusLine * lineHeight, formatSystemPowerInfo());
+    statusLine++;
+  }
+
   IPAddress ip = WiFi.softAPIP();
-  DrawIconLine(WIFI_ICON_12X12, 18+2*lineHeight, ip.toString());
+  DrawIconLine(WIFI_ICON_12X12, 18 + statusLine * lineHeight, ip.toString());
 }
 
 void DisplayManager::DrawIconLine(const uint8_t* icon, uint8_t offsetTop, String text){
@@ -102,4 +110,8 @@ String DisplayManager::formatFanInfo() const {
   line += String(static_cast<int>(fanController_.getDutyCyclePercent()));
   line += F("%");
   return line;
+}
+
+String DisplayManager::formatSystemPowerInfo() {
+  return systemPowerController_.readPowerInfo();
 }

--- a/src/DisplayManager.hpp
+++ b/src/DisplayManager.hpp
@@ -8,11 +8,13 @@
 #include "LedBrightnessController.hpp"
 #include "EmotionState.hpp"
 #include "FanController.hpp"
+#include "SystemPowerController.hpp"
 
 class DisplayManager {
 public:
   DisplayManager(uint8_t sdaPin, uint8_t sclPin, EmotionState &emotionState,
-                 FanController &fanController, LedBrightnessController &brightnessController);
+                 FanController &fanController, LedBrightnessController &brightnessController,
+                 SystemPowerController &systemPowerController);
 
   void begin();
   void update();
@@ -22,12 +24,14 @@ private:
     void DrawIconLine(const uint8_t lineOffsetPx, const uint8_t iconSize, const uint8_t textOffsetLeft);
     String formatEarInfo() const;
     String formatFanInfo() const;
+    String formatSystemPowerInfo();
     void DrawIconLine(const uint8_t* icon, uint8_t offsetTop, String text);
     uint8_t sdaPin_;
     uint8_t sclPin_;
     EmotionState &emotionState_;
     FanController &fanController_;
     LedBrightnessController &brightnessController_;
+    SystemPowerController &systemPowerController_;
     Adafruit_SH1106 display_;
 };
 

--- a/src/SystemPowerController.cpp
+++ b/src/SystemPowerController.cpp
@@ -1,0 +1,54 @@
+#include "SystemPowerController.hpp"
+
+SystemPowerController::SystemPowerController(uint8_t sdaPin, uint8_t sclPin)
+    : sdaPin_(sdaPin),
+      sclPin_(sclPin),
+      enabled_(false) {}
+
+bool SystemPowerController::begin() {
+  Wire.begin(sdaPin_, sclPin_);
+  Wire.beginTransmission(kIna226Address);
+  enabled_ = (Wire.endTransmission() == 0);
+  if (!enabled_) {
+    Serial.println(F("INA226 not found. System power monitoring disabled"));
+  }
+  return enabled_;
+}
+
+bool SystemPowerController::isEnabled() const {
+  return enabled_;
+}
+
+String SystemPowerController::readPowerInfo() {
+  if (!enabled_) {
+    return F("System power sensor is disabled");
+  }
+
+  uint16_t rawBusVoltage = 0;
+  uint16_t rawShuntVoltage = 0;
+  if (!readRegister16(kBusVoltageRegister, rawBusVoltage) || !readRegister16(kShuntVoltageRegister, rawShuntVoltage)) {
+    return F("System power read error");
+  }
+
+  const float voltage = static_cast<float>(rawBusVoltage) * 1.25f / 1000.0f;
+  const int16_t signedShuntVoltage = static_cast<int16_t>(rawShuntVoltage);
+  const float shuntMillivolts = static_cast<float>(signedShuntVoltage) * 2.5f / 1000.0f;
+  const float current = (shuntMillivolts / kShuntResistorOhms) / 1000.0f;
+
+  return String(voltage, 2) + F("V;") + String(current, 2) + F("A");
+}
+
+bool SystemPowerController::readRegister16(uint8_t reg, uint16_t &value) const {
+  Wire.beginTransmission(kIna226Address);
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) {
+    return false;
+  }
+
+  if (Wire.requestFrom(static_cast<int>(kIna226Address), 2) != 2) {
+    return false;
+  }
+
+  value = (static_cast<uint16_t>(Wire.read()) << 8) | static_cast<uint16_t>(Wire.read());
+  return true;
+}

--- a/src/SystemPowerController.hpp
+++ b/src/SystemPowerController.hpp
@@ -1,0 +1,28 @@
+#ifndef SYSTEM_POWER_CONTROLLER_HPP
+#define SYSTEM_POWER_CONTROLLER_HPP
+
+#include <Arduino.h>
+#include <Wire.h>
+
+class SystemPowerController {
+public:
+  explicit SystemPowerController(uint8_t sdaPin, uint8_t sclPin);
+
+  bool begin();
+  bool isEnabled() const;
+  String readPowerInfo();
+
+private:
+  bool readRegister16(uint8_t reg, uint16_t &value) const;
+
+  uint8_t sdaPin_;
+  uint8_t sclPin_;
+  bool enabled_;
+
+  static constexpr uint8_t kIna226Address = 0x40;
+  static constexpr uint8_t kBusVoltageRegister = 0x02;
+  static constexpr uint8_t kShuntVoltageRegister = 0x01;
+  static constexpr float kShuntResistorOhms = 0.1f;
+};
+
+#endif // SYSTEM_POWER_CONTROLLER_HPP

--- a/src/WebEndpoints/System/SystemPowerEndpoint.cpp
+++ b/src/WebEndpoints/System/SystemPowerEndpoint.cpp
@@ -1,0 +1,17 @@
+#include "WebEndpoints/System/SystemPowerEndpoint.hpp"
+
+SystemPowerEndpoint::SystemPowerEndpoint(SystemPowerController &systemPowerController)
+    : systemPowerController_(systemPowerController) {}
+
+void SystemPowerEndpoint::registerEndpoint(AsyncWebServer &server) {
+  server.on("/system-power", HTTP_GET, [this](AsyncWebServerRequest *request) { handleGet(request); });
+}
+
+void SystemPowerEndpoint::handleGet(AsyncWebServerRequest *request) {
+  if (!systemPowerController_.isEnabled()) {
+    request->send(200, "text/plain", F("System power sensor is disabled"));
+    return;
+  }
+
+  request->send(200, "text/plain", systemPowerController_.readPowerInfo());
+}

--- a/src/WebEndpoints/System/SystemPowerEndpoint.hpp
+++ b/src/WebEndpoints/System/SystemPowerEndpoint.hpp
@@ -1,0 +1,20 @@
+#ifndef WEB_ENDPOINTS_SYSTEM_SYSTEM_POWER_ENDPOINT_HPP
+#define WEB_ENDPOINTS_SYSTEM_SYSTEM_POWER_ENDPOINT_HPP
+
+#include <ESPAsyncWebServer.h>
+
+#include "SystemPowerController.hpp"
+
+class SystemPowerEndpoint {
+public:
+  explicit SystemPowerEndpoint(SystemPowerController &systemPowerController);
+
+  void registerEndpoint(AsyncWebServer &server);
+
+private:
+  void handleGet(AsyncWebServerRequest *request);
+
+  SystemPowerController &systemPowerController_;
+};
+
+#endif // WEB_ENDPOINTS_SYSTEM_SYSTEM_POWER_ENDPOINT_HPP

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -6,6 +6,7 @@ WebServerManager::WebServerManager(
     EarController &earController,
     LedBrightnessController &brightnessController,
     TiltController &tiltController,
+    SystemPowerController &systemPowerController,
     FileManager &fileManager,
     CapabilityManager &capabilityManager,
     std::function<void()> onSettingsChanged,
@@ -20,6 +21,7 @@ WebServerManager::WebServerManager(
       fanEndpoint_(fanController, onSettingsChanged),
       earsEndpoint_(brightnessController, onSettingsChanged),
       gyroEndpoint_(tiltController),
+      systemPowerEndpoint_(systemPowerController),
       capabilitiesEndpoint_(capabilityManager),
       notFoundEndpoint_()
 {
@@ -52,6 +54,7 @@ void WebServerManager::registerRoutes()
   fanEndpoint_.registerEndpoint(server_);
   earsEndpoint_.registerEndpoint(server_);
   gyroEndpoint_.registerEndpoint(server_);
+  systemPowerEndpoint_.registerEndpoint(server_);
   capabilitiesEndpoint_.registerEndpoint(server_);
   notFoundEndpoint_.registerEndpoint(server_);
 }

--- a/src/WebServerManager.hpp
+++ b/src/WebServerManager.hpp
@@ -14,6 +14,7 @@
 #include "EmotionState.hpp"
 #include "FanController.hpp"
 #include "TiltController.hpp"
+#include "SystemPowerController.hpp"
 #include "WebEndpoints/Ears/EarsEndpoint.hpp"
 #include "WebEndpoints/Fan/FanEndpoint.hpp"
 #include "WebEndpoints/Emotions/EmotionEndpoint.hpp"
@@ -21,6 +22,7 @@
 #include "WebEndpoints/Files/FileEndpoint.hpp"
 #include "WebEndpoints/Files/FilesEndpoint.hpp"
 #include "WebEndpoints/System/GyroEndpoint.hpp"
+#include "WebEndpoints/System/SystemPowerEndpoint.hpp"
 #include "Capabilities/CapabilityManager.hpp"
 #include "WebEndpoints/Capabilities/CapabilitiesEndpoint.hpp"
 #include "WebEndpoints/System/HeapEndpoint.hpp"
@@ -31,6 +33,7 @@ class WebServerManager
 public:
   WebServerManager(EmotionState &emotionState, FanController &fanController,
                    EarController &earController, LedBrightnessController &brightnessController, TiltController &tiltController,
+                   SystemPowerController &systemPowerController,
                    FileManager &fileManager,
                    CapabilityManager &capabilityManager,
                    std::function<void()> onSettingsChanged, bool allowAllFileChanges);
@@ -51,6 +54,7 @@ private:
   FanEndpoint fanEndpoint_;
   EarsEndpoint earsEndpoint_;
   GyroEndpoint gyroEndpoint_;
+  SystemPowerEndpoint systemPowerEndpoint_;
   CapabilitiesEndpoint capabilitiesEndpoint_;
   NotFoundEndpoint notFoundEndpoint_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "FanController.hpp"
 #include "SettingsStorage.hpp"
 #include "TiltController.hpp"
+#include "SystemPowerController.hpp"
 #include "WebServerManager.hpp"
 #include "BLEController.hpp"
 #include "Capabilities/CapabilityManager.hpp"
@@ -30,6 +31,7 @@ EmotionState emotionState;
 FanController fanController(FAN_PWM_PIN, FAN_PWM_CHANNEL, FAN_PWM_FREQUENCY, FAN_PWM_RESOLUTION);
 EarController earController(LEDS_PER_DISPLAY, DATA_PIN_EARS, ledBrightnessController);
 TiltController tiltController(emotionState, PIN_SDA, PIN_SCL);
+SystemPowerController systemPowerController(PIN_SDA, PIN_SCL);
 FileManager fileManager;
 SettingsStorage settingsStorage(emotionState, fanController, ledBrightnessController, earController);
 
@@ -39,17 +41,18 @@ void onSettingsChanged()
 }
 CapabilityManager capabilityManager(ledBrightnessController, fanController, onSettingsChanged);
 WebServerManager webServerManager(emotionState, fanController, earController, ledBrightnessController,
-                                  tiltController, fileManager,
+                                  tiltController, systemPowerController, fileManager,
                                   capabilityManager,
                                   onSettingsChanged, 
                                   ALLOW_ALL_FILE_CHANGES);
-DisplayManager displayManager(PIN_SDA, PIN_SCL, emotionState, fanController, ledBrightnessController);
+DisplayManager displayManager(PIN_SDA, PIN_SCL, emotionState, fanController, ledBrightnessController, systemPowerController);
 BLEController bleController(emotionState, capabilityManager); 
 
 void setup() {
   Serial.begin(115200);
 
   tiltController.begin();
+  systemPowerController.begin();
 
   if (!fileManager.begin()) {
     while (true) {


### PR DESCRIPTION
### Motivation
- Provide on-demand system voltage and current readings from an INA226 shunt/voltage sensor similar to the existing tilt controller behavior.
- Surface the sensor data via a web endpoint and show a single-line voltage/current status on the OLED only when the INA226 is present.

### Description
- Added `SystemPowerController` (`src/SystemPowerController.hpp` / `src/SystemPowerController.cpp`) which probes the INA226 at I2C address `0x40` and reads bus/shunt registers to compute voltage and current (assumes a `0.1Ω` shunt resistor). 
- Added `SystemPowerEndpoint` (`src/WebEndpoints/System/SystemPowerEndpoint.hpp` / `.cpp`) exposing `GET /system-power` and returning a disabled message when the sensor is not detected.
- Wired the controller and endpoint into app bootstrap and server routing by updating `src/main.cpp`, `src/WebServerManager.hpp`/`.cpp` to inject the controller and register the route.
- Integrated UI and display: updated `data/index.html` to add a System Power section and JS refresh flow, and updated `DisplayManager` (`src/DisplayManager.hpp` / `.cpp`) to render the voltage/current line only when the sensor is available.

### Testing
- Attempted to run a build with `pio run`, which failed because the PlatformIO CLI is not available in the execution environment (`pio: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df6cf1404832d9354e84ee603f778)